### PR TITLE
Handle error when splash image is missing.

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -163,7 +163,7 @@
 - (void)updateBounds
 {
     UIImage* img = _imageView.image;
-    CGRect imgBounds = CGRectMake(0, 0, img.size.width, img.size.height);
+    CGRect imgBounds = (img) ? CGRectMake(0, 0, img.size.width, img.size.height) : CGRectZero;
 
     CGSize screenSize = [self.viewController.view convertRect:[UIScreen mainScreen].bounds fromView:nil].size;
 
@@ -171,7 +171,7 @@
     if (CGSizeEqualToSize(screenSize, imgBounds.size)) {
         CGRect statusFrame = [self.viewController.view convertRect:[UIApplication sharedApplication].statusBarFrame fromView:nil];
         imgBounds.origin.y -= statusFrame.size.height;
-    } else {
+    } else if (imgBounds.size.width > 0) {
         CGRect viewBounds = self.viewController.view.bounds;
         CGFloat imgAspect = imgBounds.size.width / imgBounds.size.height;
         CGFloat viewAspect = viewBounds.size.width / viewBounds.size.height;


### PR DESCRIPTION
Handle error when splash image file is missing, to prevent app crashing.
