### PR TITLE
fix splash screen height on iOS7

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -19,6 +19,7 @@
 
 #import "CDVSplashScreen.h"
 
+#define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 #define kSplashScreenDurationDefault 0.25f
 
 @implementation CDVSplashScreen
@@ -169,8 +170,11 @@
 
     // There's a special case when the image is the size of the screen.
     if (CGSizeEqualToSize(screenSize, imgBounds.size)) {
-        CGRect statusFrame = [self.viewController.view convertRect:[UIApplication sharedApplication].statusBarFrame fromView:nil];
-        imgBounds.origin.y -= statusFrame.size.height;
+        // Status frame height doesn't count on iOS7, so don't subtract it
+        if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
+            CGRect statusFrame = [self.viewController.view convertRect:[UIApplication sharedApplication].statusBarFrame fromView:nil];
+            imgBounds.origin.y -= statusFrame.size.height;
+        }
     } else {
         CGRect viewBounds = self.viewController.view.bounds;
         CGFloat imgAspect = imgBounds.size.width / imgBounds.size.height;


### PR DESCRIPTION
On iOS7, the status bar doesn't need to be offset from the splash screen height because of the new 'full screen' style of apps. The PR just adds a check for < v7.0 before subtracting the status bar height.

Tested in simulator for iOS 6.1 and 7.0 on both 3.5 and 4 inch models and fixes the issue.

EDIT: This PR refers to the issue being tracked at https://issues.apache.org/jira/browse/CB-4391
