### PR TITLE
Plugin did not accept commands via JS Bridge anymore, as CDVInvokedUrlCo...

### DIFF
--- a/src/ios/CDVSplashScreen.h
+++ b/src/ios/CDVSplashScreen.h
@@ -19,6 +19,7 @@
 
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVInvokedUrlCommand.h>
 
 @interface CDVSplashScreen : CDVPlugin {
     UIActivityIndicatorView* _activityView;


### PR DESCRIPTION
CDVInvokedUrlCommand.h was missing from the headers file.

Signed-off-by: Sidney Bofah sidney.bofah@googlemail.com
