### PR TITLE
[CB-3562] Fix aspect ratio on landscape-only iPhone applications

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -166,6 +166,18 @@
     CGRect imgBounds = (img) ? CGRectMake(0, 0, img.size.width, img.size.height) : CGRectZero;
 
     CGSize screenSize = [self.viewController.view convertRect:[UIScreen mainScreen].bounds fromView:nil].size;
+    UIInterfaceOrientation orientation = self.viewController.interfaceOrientation;
+    CGAffineTransform imgTransform = CGAffineTransformIdentity;
+
+    /* If and only if an iPhone application is landscape-only as per
+     * UISupportedInterfaceOrientations, the view controller's orientation is
+     * landscape. In this case the image must be rotated in order to appear
+     * correctly.
+     */
+    if (UIInterfaceOrientationIsLandscape(orientation) && !CDV_IsIPad()) {
+        imgTransform = CGAffineTransformMakeRotation(M_PI / 2);
+        imgBounds.size = CGSizeMake(imgBounds.size.height, imgBounds.size.width);
+    }
 
     // There's a special case when the image is the size of the screen.
     if (CGSizeEqualToSize(screenSize, imgBounds.size)) {
@@ -188,6 +200,7 @@
         imgBounds.size.width *= ratio;
     }
 
+    _imageView.transform = imgTransform;
     _imageView.frame = imgBounds;
 }
 


### PR DESCRIPTION
The splash screen is shown with a faulty aspect ratio for landscape-only applications on iPhone/iPod touch devices. This is fixed by applying a 90° rotational transformation.
