### PR TITLE
Fix ios launchimage

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -147,6 +147,9 @@
         }
     }
 
+     // Provides device specific Launch Images for universal apps
+    imageName = CDV_IsIPad() ? [imageName stringByAppendingString:@"~ipad"] : [imageName stringByAppendingString:@"~iphone"];
+
     if (![imageName isEqualToString:_curImageName]) {
         UIImage* img = [UIImage imageNamed:imageName];
         _imageView.image = img;


### PR DESCRIPTION
Xcode throws a warning because he can't find a "Default-Portrait" launch image.
In order to respect the Cordova filename convention we should build it as follow:

<pre>basename + usage_specific_modifiers + scale_modifier + device_modifier + .png</pre>


(Source: https://developer.apple.com/library/ios/DOCUMENTATION/iPhone/Conceptual/iPhoneOSProgrammingGuide/App-RelatedResources/App-RelatedResources.html#//apple_ref/doc/uid/TP40007072-CH6-SW12)
