### PR TITLE
Fix logic when setting the iPad splash screen

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -138,18 +138,22 @@
 
     if (CDV_IsIPhone5()) {
         imageName = [imageName stringByAppendingString:@"-568h"];
-    } else if (CDV_IsIPad() && isOrientationLocked) {
-        switch (orientation) {
-            case UIInterfaceOrientationLandscapeLeft:
-            case UIInterfaceOrientationLandscapeRight:
-                imageName = [imageName stringByAppendingString:@"-Landscape"];
-                break;
+    } else if (CDV_IsIPad()) {
+        if (isOrientationLocked) {
+            imageName = [imageName stringByAppendingString:(supportsLandscape ? @"-Landscape" : @"-Portrait")];
+        } else {
+            switch (orientation) {
+                case UIInterfaceOrientationLandscapeLeft:
+                case UIInterfaceOrientationLandscapeRight:
+                    imageName = [imageName stringByAppendingString:@"-Landscape"];
+                    break;
 
-            case UIInterfaceOrientationPortrait:
-            case UIInterfaceOrientationPortraitUpsideDown:
-            default:
-                imageName = [imageName stringByAppendingString:@"-Portrait"];
-                break;
+                case UIInterfaceOrientationPortrait:
+                case UIInterfaceOrientationPortraitUpsideDown:
+                default:
+                    imageName = [imageName stringByAppendingString:@"-Portrait"];
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
When running Cordova apps without orientation lock on iPads, the
Splash Screen plugin didn't work properly. It would skip the iPad-
specific splash screen logic, and just select the image named
@"Default.png" (without adding the orientation suffix), and print
the following messages in the console:

WARNING: The splashscreen image named Default was not found

Now, for iPads, the splash screen image is set by first looking
at the position of the orientation lock, and if that is not set, it
uses the calculated view orientation.
