### PR TITLE
Splashscreen crash on WP8

### DIFF
--- a/src/wp/SplashScreen.cs
+++ b/src/wp/SplashScreen.cs
@@ -95,13 +95,13 @@ namespace WPCordovaClassLib.Cordova.Commands
 
         public void show(string options = null)
         {
-            if (popup.IsOpen)
-            {
-                return;
-            }
-
             Deployment.Current.Dispatcher.BeginInvoke(() =>
             {
+                if (popup.IsOpen)
+                {
+                    return;
+                }
+
                 popup.Child.Opacity = 0;
 
                 Storyboard story = new Storyboard();
@@ -143,6 +143,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 {
                     return;
                 }
+
                 popup.Child.Opacity = 1.0;
 
                 Storyboard story = new Storyboard();


### PR DESCRIPTION
The UI elements cannot be accessed from any other than the UI thread directly. So, enclose UI access code in the Dispatcher.BeginInvoke()
