### PR TITLE
fixed "WARNING: The splashscreen image named Default was not found"

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -124,12 +124,6 @@
     // Use UILaunchImageFile if specified in plist.  Otherwise, use Default.
     NSString* imageName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchImageFile"];
 
-    // Checks to see if the developer has locked the orientation to use only one of Portrait or Landscape
-    CDVViewController* vc = (CDVViewController*)self.viewController;
-    BOOL supportsLandscape = [vc supportsOrientation:UIInterfaceOrientationLandscapeLeft] || [vc supportsOrientation:UIInterfaceOrientationLandscapeRight];
-    BOOL supportsPortrait = [vc supportsOrientation:UIInterfaceOrientationPortrait] || [vc supportsOrientation:UIInterfaceOrientationPortraitUpsideDown];
-    BOOL isOrientationLocked = !(supportsPortrait && supportsLandscape);
-
     if (imageName) {
         imageName = [imageName stringByDeletingPathExtension];
     } else {
@@ -138,25 +132,21 @@
 
     if (CDV_IsIPhone5()) {
         imageName = [imageName stringByAppendingString:@"-568h"];
-    } else if (CDV_IsIPad()) {
-        if (isOrientationLocked) {
-            imageName = [imageName stringByAppendingString:(supportsLandscape ? @"-Landscape" : @"-Portrait")];
-        } else {
-            switch (orientation) {
-                case UIInterfaceOrientationLandscapeLeft:
-                case UIInterfaceOrientationLandscapeRight:
-                    imageName = [imageName stringByAppendingString:@"-Landscape"];
-                    break;
+    } else if (CDV_IsIPad()){
 
-                case UIInterfaceOrientationPortrait:
-                case UIInterfaceOrientationPortraitUpsideDown:
-                default:
-                    imageName = [imageName stringByAppendingString:@"-Portrait"];
-                    break;
-            }
-        }
+        // Checks to see if the developer has locked the orientation to use only one of Portrait or Landscape
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        BOOL supportsLandscape = [vc supportsOrientation:UIInterfaceOrientationLandscapeLeft] || [vc supportsOrientation:UIInterfaceOrientationLandscapeRight];
+        BOOL supportsPortrait = [vc supportsOrientation:UIInterfaceOrientationPortrait] || [vc supportsOrientation:UIInterfaceOrientationPortraitUpsideDown];
+        BOOL isOrientationLocked = !(supportsPortrait && supportsLandscape);
+        BOOL orientationIsLandscape = orientation == UIInterfaceOrientationLandscapeLeft || orientation == UIInterfaceOrientationLandscapeRight;
+        
+        BOOL useLandscape = isOrientationLocked ? supportsLandscape : orientationIsLandscape;
+
+        NSString *iPadSuffix = useLandscape ? @"-Landscape" : @"-Portrait";
+        imageName = [imageName stringByAppendingString:iPadSuffix];
     }
-
+    
     if (![imageName isEqualToString:_curImageName]) {
         UIImage* img = [UIImage imageNamed:imageName];
         _imageView.image = img;


### PR DESCRIPTION
fixed "WARNING: The splashscreen image named Default was not found" with iOS and iPad for default project built by cordova 3.5.0-0.2.6

Now selects imageName "Default-Landscape" or "Default-Portrait" based on the current orientation, if the orientation isn't locked.