### PR TITLE
Added support for iPhone 6 and iPhone 6 Plus resolutions

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -136,9 +136,18 @@
         imageName = @"Default";
     }
 
-    if (CDV_IsIPhone5()) {
-        imageName = [imageName stringByAppendingString:@"-568h"];
-    } else if (CDV_IsIPad()) {
+    CGSize screenSize = [[UIScreen mainScreen] bounds].size;
+    NSInteger length = (NSInteger)MAX(screenSize.width, screenSize.height);
+    switch (length) {
+        case 568:
+        case 667:
+        case 736:
+            imageName = [imageName stringByAppendingFormat:@"-%ldh", length];   // e.g. -568h
+            break;
+        default:
+            break;
+    };
+    if (CDV_IsIPad() && isOrientationLocked) {
         if (isOrientationLocked) {
             imageName = [imageName stringByAppendingString:(supportsLandscape ? @"-Landscape" : @"-Portrait")];
         } else {


### PR DESCRIPTION
The iPhone 6 and iPhone 6 Plus brings new resolutions for the splash screen. Taking the same approach as with the iPhone 5 (image name postfixed -568h), i.e. using the postfixes -667h and -736h for iPhone 6 and iPhone 6 Plus respectively.
