### PR TITLE
Support iPhone 6/6+ by using UILaunchStoryboardName NIB if available

### DIFF
--- a/src/ios/CDVSplashScreen.h
+++ b/src/ios/CDVSplashScreen.h
@@ -22,7 +22,7 @@
 
 @interface CDVSplashScreen : CDVPlugin {
     UIActivityIndicatorView* _activityView;
-    UIImageView* _imageView;
+    UIView* _splashView;
     NSString* _curImageName;
     BOOL _visible;
 }


### PR DESCRIPTION
I need to support the larger iPhone 6 and 6 Plus screens in a project I'm working on so adapted this plugin to use a Launch Screen NIB if available.

I've adapted the plugin to load the NIB specified by the UILaunchStoryboardName key in the Info.plist. It will then palce a UIView taken from this NIB over the top of the application in lieu of the regular UIImageView.

I haven't tested this approach on iPad or when launching in landscape mode and I do not currently support Storyboard launch screens. Figured I'd nonetheless submit the PR in case it's useful to anyone else.
