### PR TITLE
Fix for portrait/landscape detection

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -124,16 +124,19 @@
     
     UIScreen* mainScreen = [UIScreen mainScreen];
     CGFloat mainScreenHeight = mainScreen.bounds.size.height;
+    CGFloat mainScreenWidth = mainScreen.bounds.size.width;
+    
+    int limit = MAX(mainScreenHeight,mainScreenWidth);
     
     device.iPad = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
     device.iPhone = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone);
     device.retina = ([mainScreen scale] == 2.0);
-    device.iPhone5 = (device.iPhone && mainScreenHeight == 568.0);
+    device.iPhone5 = (device.iPhone && limit == 568.0);
     // note these below is not a true device detect, for example if you are on an
     // iPhone 6/6+ but the app is scaled it will prob set iPhone5 as true, but
     // this is appropriate for detecting the runtime screen environment
-    device.iPhone6 = (device.iPhone && mainScreenHeight == 667.0);
-    device.iPhone6Plus = (device.iPhone && mainScreenHeight == 736.0);
+    device.iPhone6 = (device.iPhone && limit == 667.0);
+    device.iPhone6Plus = (device.iPhone && limit == 736.0);
     
     return device;
 }


### PR DESCRIPTION
Sometimes the width can be 568 or 320 depending on orientation on iPhone 5. This fixes the detection.
