### PR TITLE
Fixed plugin name in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This plugin displays and hides a splash screen during application launch.
 
 ## Installation
 
-    cordova plugin add cordova-plugin-splashscreen
+    cordova plugin add org.apache.cordova.splashscreen
 
 
 ## Supported Platforms


### PR DESCRIPTION
While I was installing this on a small project, I noticed that the reference to the plugin name was wrong in the README. Here is a quick pull request that fixes that.