### PR TITLE
Fixed installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This plugin displays and hides a splash screen during application launch.
 
 ## Installation
 
-    cordova plugin add cordova-plugin-splashscreen
+    cordova plugin add org.apache.cordova.splashscreen
 
 
 ## Supported Platforms


### PR DESCRIPTION
Current instructions yield an error in NPM:

cordova plugin add cordova-plugin-splashscreen
Fetching plugin "cordova-plugin-splashscreen" via plugin registry
npm http GET http://registry.cordova.io/cordova-plugin-splashscreen
npm http 404 http://registry.cordova.io/cordova-plugin-splashscreen
Error: 404 Not Found: cordova-plugin-splashscreen
    at RegClient.<anonymous> (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/node_modules/npm/node_modules/npm-registry-client/lib/request.js:268:14)
    at Request.self.callback (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/node_modules/npm/node_modules/request/index.js:148:22)
    at Request.emit (events.js:110:17)
    at Request.<anonymous> (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/node_modules/npm/node_modules/request/index.js:876:14)
    at Request.emit (events.js:129:20)
    at IncomingMessage.<anonymous> (/usr/local/lib/node_modules/cordova/node_modules/cordova-lib/node_modules/npm/node_modules/request/index.js:827:12)
    at IncomingMessage.emit (events.js:129:20)
    at _stream_readable.js:908:16
    at process._tickCallback (node.js:355:11)