### PR TITLE
CB-8750 [wp8]: Allow resolution-specific splashscreen images

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@
 
         <source-file src="src/android/SplashScreen.java" target-dir="src/org/apache/cordova/splashscreen" />
     </platform>
-    
+
     <!-- ubuntu -->
     <platform name="ubuntu">
         <header-file src="src/ubuntu/splashscreen.h" />
@@ -98,6 +98,7 @@
         </config-file>
 
         <source-file src="src/wp/SplashScreen.cs" />
+        <source-file src="src/wp/ResolutionHelper.cs" />
 
     </platform>
 
@@ -111,6 +112,7 @@
         </config-file>
 
         <source-file src="src/wp/SplashScreen.cs" />
+        <source-file src="src/wp/ResolutionHelper.cs" />
 
     </platform>
 

--- a/src/wp/ResolutionHelper.cs
+++ b/src/wp/ResolutionHelper.cs
@@ -1,0 +1,60 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+using Microsoft.Phone.Info;
+using System;
+using System.Windows;
+
+namespace WPCordovaClassLib.Cordova.Commands
+{
+    public enum Resolutions { WVGA, WXGA, HD };
+
+    public static class ResolutionHelper
+    {
+        private static bool IsWvga
+        {
+            get
+            {
+                return Application.Current.Host.Content.ScaleFactor == 100;
+            }
+        }
+
+        private static bool IsWxga
+        {
+            get
+            {
+                return Application.Current.Host.Content.ScaleFactor == 160;
+            }
+        }
+
+        private static bool IsHD
+        {
+            get
+            {
+                return Application.Current.Host.Content.ScaleFactor == 150;
+            }
+        }
+
+        public static Resolutions CurrentResolution
+        {
+            get
+            {
+                if (IsWvga) return Resolutions.WVGA;
+                else if (IsWxga) return Resolutions.WXGA;
+                else if (IsHD) return Resolutions.HD;
+                else throw new InvalidOperationException("Unknown resolution");
+            }
+        }
+    }
+}

--- a/src/wp/SplashScreen.cs
+++ b/src/wp/SplashScreen.cs
@@ -1,10 +1,10 @@
-/*  
+/*
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,7 @@ namespace WPCordovaClassLib.Cordova.Commands
         private Popup popup;
 
         // Time until we dismiss the splashscreen
-        private int prefDelay = 3000; 
+        private int prefDelay = 3000;
 
         // Whether we hide it by default
         private bool prefAutoHide = true;
@@ -66,8 +66,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 Stretch = Stretch.Fill
             };
 
-            Uri imagePath = new Uri(prefImagePath, UriKind.RelativeOrAbsolute);
-            var imageResource = Application.GetResourceStream(imagePath);
+            var imageResource = GetSplashScreenImageResource();
             if (imageResource != null)
             {
                 BitmapImage splash_image = new BitmapImage();
@@ -76,7 +75,7 @@ namespace WPCordovaClassLib.Cordova.Commands
             }
 
             // Instansiate the popup and set the Child property of Popup to SplashScreen
-            popup = new Popup() { IsOpen = false, 
+            popup = new Popup() { IsOpen = false,
                                   Child = SplashScreen,
                                   HorizontalAlignment = HorizontalAlignment.Stretch,
                                   VerticalAlignment = VerticalAlignment.Center
@@ -133,10 +132,56 @@ namespace WPCordovaClassLib.Cordova.Commands
             }
         }
 
+        private StreamResourceInfo GetSplashScreenImageResource()
+        {
+            // Get the base filename for the splash screen images
+            string imageName = System.IO.Path.GetFileNameWithoutExtension(prefImagePath);
+            Uri imageUri = null;
+            StreamResourceInfo imageResource = null;
+
+            // First, try to get a resolution-specific splashscreen
+            try
+            {
+                // Determine the device's resolution
+                switch (ResolutionHelper.CurrentResolution)
+                {
+                    case Resolutions.HD:
+                        imageUri = new Uri(imageName + ".screen-720p.jpg", UriKind.Relative);
+                        break;
+
+                    case Resolutions.WVGA:
+                        imageUri = new Uri(imageName + ".screen-WVGA.jpg", UriKind.Relative);
+                        break;
+
+                    case Resolutions.WXGA:
+                    default:
+                        imageUri = new Uri(imageName + ".screen-WXGA.jpg", UriKind.Relative);
+                        break;
+                }
+
+                imageResource = Application.GetResourceStream(imageUri);
+            }
+            catch (Exception)
+            {
+                // It's OK if we didn't get a resolution-specific image
+            }
+
+            // Fallback to the default image name without decoration
+            if (imageResource == null)
+            {
+                imageUri = new Uri(prefImagePath, UriKind.Relative);
+                imageResource = Application.GetResourceStream(imageUri);
+            }
+
+            if (imageUri != null) Debug.WriteLine("INFO :: SplashScreen: using image {0}", imageUri.OriginalString);
+
+            return imageResource;
+        }
+
         public void show(string options = null)
         {
 
-            if (!popup.IsOpen)    
+            if (!popup.IsOpen)
             {
                 Deployment.Current.Dispatcher.BeginInvoke(() =>
                 {


### PR DESCRIPTION
There are two aspect ratios for Windows Phone devices: 15:9 and 16:9. At
the moment, though, there is only one splash screen by default for WP8
Cordova apps. When stretched to fit all possible resolutions, this can
sometimes look bad.

WP supports resolution-specific splashscreens, so this commit adds the
same support to the splashscreen plugin. It uses the same base name for
the splashscreen, but adds modifiers such as ".screen-[res]" based on
the device. If a screen-specific image is found, it is used. If not, we
fall back to the single default image.

Fixes https://issues.apache.org/jira/browse/CB-8750