### PR TITLE
CB-8758 [wp8]: UnauthorizedAccessException on hide()

### DIFF
--- a/src/wp/SplashScreen.cs
+++ b/src/wp/SplashScreen.cs
@@ -135,10 +135,9 @@ namespace WPCordovaClassLib.Cordova.Commands
 
         public void show(string options = null)
         {
-
-            if (!popup.IsOpen)    
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
             {
-                Deployment.Current.Dispatcher.BeginInvoke(() =>
+                if (!popup.IsOpen)
                 {
                     popup.Child.Opacity = 0;
 
@@ -162,17 +161,16 @@ namespace WPCordovaClassLib.Cordova.Commands
                     {
                         StartAutoHideTimer();
                     }
-                });
-            }
+                }
+            });
         }
 
         public void hide(string options = null)
         {
-            if (popup.IsOpen)
+            Deployment.Current.Dispatcher.BeginInvoke(() =>
             {
-                Deployment.Current.Dispatcher.BeginInvoke(() =>
+                if (popup.IsOpen)
                 {
-
                     popup.Child.Opacity = 1.0;
 
                     Storyboard story = new Storyboard();
@@ -191,8 +189,8 @@ namespace WPCordovaClassLib.Cordova.Commands
                         popup.IsOpen = false;
                     };
                     story.Begin();
-                });
-            }
+                }
+            });
         }
 
         private void StartAutoHideTimer()


### PR DESCRIPTION
When calling hide() from JS, the attempt to access Popup could happen on
a background thread, which ends up throwing an
UnauthorizedAccessException about cross-thread access.

To address this, it's best to check the popup's state from within the UI
thread.

Fixes https://issues.apache.org/jira/browse/CB-8758