### PR TITLE
CB-8753 Maintain splash screen aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,14 @@ In your `config.xml`, you need to add the following preferences:
 
     <preference name="SplashScreen" value="foo" />
     <preference name="SplashScreenDelay" value="10000" />
+    <preference name="SplashMaintainAspectRatio" value="true|false" />
 
 Where foo is the name of the splashscreen file, preferably a 9 patch file. Make sure to add your splashcreen files to your res/xml directory under the appropriate folders. The second parameter represents how long the splashscreen will appear in milliseconds. It defaults to 3000 ms. See [Icons and Splash Screens](http://cordova.apache.org/docs/en/edge/config_ref_images.md.html)
 for more information.
+
+"SplashMaintainAspectRatio" preference is optional. If set to true, splash screen drawable is not stretched to fit screen, but instead simply "covers" the screen, like CSS "background-size:cover". This is very useful when splash screen images cannot be distorted in any way, for example when they contain scenery or text. This setting works best with images that have large margins (safe areas) that can be safely cropped on screens with different aspect ratios.
+ 
+The plugin reloads splash drawable whenever orientation changes, so you can specify different drawables for portrait and landscape orientations.
 
 ### Browser Quirks
 

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -247,25 +247,18 @@ public class SplashScreen extends CordovaPlugin {
                 // Get reference to display
                 Display display = cordova.getActivity().getWindowManager().getDefaultDisplay();
                 Context context = webView.getContext();
-
-                // Create the layout for the dialog
-                LinearLayout root = new LinearLayout(context);
-                root.setMinimumHeight(display.getHeight());
-                root.setMinimumWidth(display.getWidth());
-                root.setOrientation(LinearLayout.VERTICAL);
-
-                // TODO: Use the background color of the webView's parent instead of using the
-                // preference.
-                root.setBackgroundColor(preferences.getInteger("backgroundColor", Color.BLACK));
-                
-                root.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT, 0.0F));
                 
                 // Use an ImageView to render the image because of its flexible scaling options.
                 splashImageView = new ImageView(context);
                 splashImageView.setImageResource(drawableId);
                 LayoutParams layoutParams = new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
                 splashImageView.setLayoutParams(layoutParams);
+                
+                splashImageView.setMinimumHeight(display.getHeight());
+                splashImageView.setMinimumWidth(display.getWidth());
+
+                // TODO: Use the background color of the webView's parent instead of using the preference.
+                splashImageView.setBackgroundColor(preferences.getInteger("backgroundColor", Color.BLACK));
 
                 if (isMaintainAspectRatio()) {
                     // CENTER_CROP scale mode is equivalent to CSS "background-size:cover"
@@ -275,7 +268,6 @@ public class SplashScreen extends CordovaPlugin {
                     // FIT_XY scales image non-uniformly to fit into image view.
                     splashImageView.setScaleType(ImageView.ScaleType.FIT_XY);
                 }
-                root.addView(splashImageView);
 
                 // Create and show the dialog
                 splashDialog = new Dialog(context, android.R.style.Theme_Translucent_NoTitleBar);
@@ -285,7 +277,7 @@ public class SplashScreen extends CordovaPlugin {
                     splashDialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                             WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
-                splashDialog.setContentView(root);
+                splashDialog.setContentView(splashImageView);
                 splashDialog.setCancelable(false);
                 splashDialog.show();
 

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -25,8 +25,6 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Handler;
-import android.os.Looper;
-import android.util.Log;
 import android.view.Display;
 import android.view.View;
 import android.view.ViewGroup;

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -25,6 +25,8 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
 import android.view.Display;
 import android.view.View;
 import android.view.ViewGroup;
@@ -206,16 +208,10 @@ public class SplashScreen extends CordovaPlugin {
     }
 
     private void reloadDrawable() {
-        if (isReloadOnOrientationChange() && splashImageView != null) {
-            final int drawableId = preferences.getInteger("SplashDrawableId", 0);
+        if (splashImageView != null && isReloadOnOrientationChange()) {
+            int drawableId = preferences.getInteger("SplashDrawableId", 0);
             if (drawableId != 0) {
-                cordova.getActivity().runOnUiThread(new Runnable() {
-                    public void run() {
-                        if (splashImageView != null) {
-                            splashImageView.setImageDrawable(cordova.getActivity().getResources().getDrawable(drawableId));
-                        }
-                    }
-                });
+                splashImageView.setImageDrawable(cordova.getActivity().getResources().getDrawable(drawableId));
             }
         }
     }

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -27,7 +27,6 @@ import android.graphics.Color;
 import android.os.Handler;
 import android.view.Display;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import android.view.WindowManager;
 import android.widget.ImageView;
@@ -39,19 +38,6 @@ import org.apache.cordova.CordovaWebView;
 import org.json.JSONArray;
 import org.json.JSONException;
 
-/**
- * Splash Screen plugin. Uses the following preferences:
- * <ul>
- * <li>SplashScreen: Splash screen resource name.</li>
- * <li>SplashScreenDelay: How long splash screen should be shown in milliseconds.</li>
- * <li>SplashMaintainAspectRatio: Maintain aspect ratio of the drawable, like CSS
- *	background-size:cover. Defaults to false for backward compatibility.</li>
- * <li>SplashReloadOnOrientationChange: Reload splash drawable when orientation changes.
- * 	Defaults to false for performance reasons because there is no need to look up and
- *  reload the drawable if it does not change. App developer knows if they have different
- *  drawables per orientation and can set this to true in that case.</li>
- * </ul>
- */
 public class SplashScreen extends CordovaPlugin {
     private static final String LOG_TAG = "SplashScreen";
     // Cordova 3.x.x has a copy of this plugin bundled with it (SplashScreenInternal.java).
@@ -112,13 +98,6 @@ public class SplashScreen extends CordovaPlugin {
      */
     private boolean isMaintainAspectRatio () {
         return preferences.getBoolean("SplashMaintainAspectRatio", false);
-    }
-    
-    /**
-     * Shorter way to check value of "SplashReloadOnOrientationChange" preference.
-     */
-    private boolean isReloadOnOrientationChange () {
-        return preferences.getBoolean("SplashReloadOnOrientationChange", false);
     }
 
     @Override
@@ -198,18 +177,15 @@ public class SplashScreen extends CordovaPlugin {
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
-        // Reload splash drawable when orientation changes if so configured.
         if (newConfig.orientation != orientation) {
             orientation = newConfig.orientation;
-            reloadDrawable();
-        }
-    }
-
-    private void reloadDrawable() {
-        if (splashImageView != null && isReloadOnOrientationChange()) {
-            int drawableId = preferences.getInteger("SplashDrawableId", 0);
-            if (drawableId != 0) {
-                splashImageView.setImageDrawable(cordova.getActivity().getResources().getDrawable(drawableId));
+            
+            // Splash drawable may change with orientation, so reload it.
+            if (splashImageView != null) {
+                int drawableId = preferences.getInteger("SplashDrawableId", 0);
+                if (drawableId != 0) {
+                    splashImageView.setImageDrawable(cordova.getActivity().getResources().getDrawable(drawableId));
+                }
             }
         }
     }


### PR DESCRIPTION
This pull request implements https://issues.apache.org/jira/browse/CB-8753.

* Added "SplashMaintainAspectRatio” preference to maintain SplashScreen
aspect ratio instead of scaling it to dialog.
* Added “SplashReloadOnOrientationChange” preference to reload drawable
when orientation changes. It's a preference for performance reasons - do
not reload the drawable if it does not change based on orientation.