### PR TITLE
CB-10255 Add options to hide splashscreen navigation and status bars on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,14 @@ In your `config.xml`, you need to add the following preferences:
     <preference name="SplashScreen" value="foo" />
     <preference name="SplashScreenDelay" value="3000" />
     <preference name="SplashMaintainAspectRatio" value="true|false" />
+    <preference name="SplashForceFullScreen" value="true|false" />
 
 Where foo is the name of the splashscreen file, preferably a 9 patch file. Make sure to add your splashcreen files to your res/xml directory under the appropriate folders. The second parameter represents how long the splashscreen will appear in milliseconds. It defaults to 3000 ms. See [Icons and Splash Screens](http://cordova.apache.org/docs/en/edge/config_ref_images.md.html)
 for more information.
 
 "SplashMaintainAspectRatio" preference is optional. If set to true, splash screen drawable is not stretched to fit screen, but instead simply "covers" the screen, like CSS "background-size:cover". This is very useful when splash screen images cannot be distorted in any way, for example when they contain scenery or text. This setting works best with images that have large margins (safe areas) that can be safely cropped on screens with different aspect ratios.
+
+"SplashForceFullScreen" preference is optional. If set to true, the on-screen navigation and status bars are hidden while the splash screen is displayed.
 
 The plugin reloads splash drawable whenever orientation changes, so you can specify different drawables for portrait and landscape orientations.
 

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -101,6 +101,10 @@ public class SplashScreen extends CordovaPlugin {
         return preferences.getBoolean("SplashMaintainAspectRatio", false);
     }
 
+    private boolean isForceFullScreen() {
+        return preferences.getBoolean("SplashForceFullScreen", false);
+    }
+
     @Override
     public void onPause(boolean multitasking) {
         if (HAS_BUILT_IN_SPLASH_SCREEN) {
@@ -255,6 +259,10 @@ public class SplashScreen extends CordovaPlugin {
                 }
                 splashDialog.setContentView(splashImageView);
                 splashDialog.setCancelable(false);
+                if (isForceFullScreen()) {
+                    splashDialog.getWindow().getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN);
+                }
                 splashDialog.show();
 
                 // Set Runnable to remove splash screen just in case


### PR DESCRIPTION
This change adds settings to hide the navigation and status bars while the splash screen is displayed. Full-screen apps aren't affected.
