### PR TITLE
CB-8988: Fix rotation on iOS/iPad

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -204,7 +204,7 @@
 // Sets the view's frame and image.
 - (void)updateImage
 {
-    NSString* imageName = [self getImageName:self.viewController.interfaceOrientation delegate:(id<CDVScreenOrientationDelegate>)self.viewController device:[self getCurrentDevice]];
+    NSString* imageName = [self getImageName:[[UIApplication sharedApplication] statusBarOrientation] delegate:(id<CDVScreenOrientationDelegate>)self.viewController device:[self getCurrentDevice]];
 
     if (![imageName isEqualToString:_curImageName]) {
         UIImage* img = [UIImage imageNamed:imageName];


### PR DESCRIPTION
The viewController.interfaceOrientation passed to getImageName has not
yet been updated with the new orientation, even when the frame/bounds
change event has fired. Thus, the plugin never actually loads the
correct image for the new orientation. Instead, it poorly scales the
existing image.

This fix uses the statusBarOrientation property of the UIApplication
object to detect the actual orientation, and correctly load the right
image.

Fixes https://issues.apache.org/jira/browse/CB-8988