### PR TITLE
CB-3562: Disable screen rotation for iPhone when splash screen is shown (updated)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -74,8 +74,10 @@
 		    </feature>
         </config-file>
 
-	    <header-file src="src/ios/CDVSplashScreen.h" />
-	    <source-file src="src/ios/CDVSplashScreen.m" />
+        <header-file src="src/ios/CDVSplashScreen.h" />
+        <source-file src="src/ios/CDVSplashScreen.m" />
+        <header-file src="src/ios/CDVViewController+SplashScreen.h" />
+        <source-file src="src/ios/CDVViewController+SplashScreen.m" />
 
 	    <framework src="CoreGraphics.framework" />
     </platform>

--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -20,6 +20,7 @@
 #import "CDVSplashScreen.h"
 #import <Cordova/CDVViewController.h>
 #import <Cordova/CDVScreenOrientationDelegate.h>
+#import "CDVViewController+SplashScreen.h"
 
 #define kSplashScreenDurationDefault 0.25f
 
@@ -68,6 +69,16 @@
      *     gray       = UIActivityIndicatorViewStyleGray
      *
      */
+
+    // Determine whether rotation should be enabled for this device
+    // Per iOS HIG, landscape is only supported on iPad and iPhone 6+
+    CDV_iOSDevice device = [self getCurrentDevice];
+    BOOL autorotateValue = (device.iPad || device.iPhone6Plus) ?
+        [(CDVViewController *)self.viewController shouldAutorotateDefaultValue] :
+        NO;
+    
+    [(CDVViewController *)self.viewController setEnabledAutorotation:autorotateValue];
+
     NSString* topActivityIndicator = [self.commandDelegate.settings objectForKey:[@"TopActivityIndicator" lowercaseString]];
     UIActivityIndicatorViewStyle topActivityIndicatorStyle = UIActivityIndicatorViewStyleGray;
 
@@ -107,6 +118,8 @@
 
 - (void)destroyViews
 {
+    [(CDVViewController *)self.viewController setEnabledAutorotation:[(CDVViewController *)self.viewController shouldAutorotateDefaultValue]];
+
     [_imageView removeFromSuperview];
     [_activityView removeFromSuperview];
     _imageView = nil;

--- a/src/ios/CDVViewController+SplashScreen.h
+++ b/src/ios/CDVViewController+SplashScreen.h
@@ -1,0 +1,28 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Cordova/CDVViewController.h>
+
+@interface CDVViewController (SplashScreen)
+
+@property (nonatomic, assign) BOOL enabledAutorotation;
+@property (nonatomic, readonly) BOOL shouldAutorotateDefaultValue;
+
+
+@end

--- a/src/ios/CDVViewController+SplashScreen.m
+++ b/src/ios/CDVViewController+SplashScreen.m
@@ -1,0 +1,82 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "CDVViewController+SplashScreen.h"
+#import <objc/runtime.h>
+
+@implementation CDVViewController (SplashScreen)
+
+@dynamic enabledAutorotation;
+
+- (void)setEnabledAutorotation:(BOOL)value
+{
+    objc_setAssociatedObject(self,
+                             @selector(enabledAutorotation),
+                             [NSNumber numberWithBool:value],
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL)enabledAutorotation
+{
+    NSNumber *number =  (NSNumber *)objc_getAssociatedObject(self, @selector(enabledAutorotation));
+    return [number boolValue];
+}
+
++ (void)load
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+        
+        SEL originalSelector = @selector(shouldAutorotate);
+        SEL swizzledSelector = @selector(splash_shouldAutorotate);
+        
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+        
+        BOOL didAddMethod = class_addMethod(class,
+                                            originalSelector,
+                                            method_getImplementation(swizzledMethod),
+                                            method_getTypeEncoding(swizzledMethod));
+        
+        if (didAddMethod) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
+#pragma mark - Method Swizzling
+
+- (BOOL)splash_shouldAutorotate
+{
+    return self.enabledAutorotation;
+}
+
+
+- (BOOL)shouldAutorotateDefaultValue
+{
+    return [self splash_shouldAutorotate];
+}
+
+@end


### PR DESCRIPTION
This is an updated port of emarashliev's fix for CB-3562, as this bug still exists. The original PR #14 seems to be dead, however. I ported these changes over to the latest branch of the plugin, and made some minor adjustments to avoid deprecated functions.

@shazron @agrieve Given the discussion in the previous PR, hopefully this can be reviewed and incorporated quickly.