### PR TITLE
CB-9094: Smarter autohide logic on Android

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -51,6 +51,7 @@ public class SplashScreen extends CordovaPlugin {
     private static Dialog splashDialog;
     private static ProgressDialog spinnerDialog;
     private static boolean firstShow = true;
+    private static boolean shouldAutoHide = true;
 
     /**
      * Displays the splash drawable.
@@ -265,6 +266,8 @@ public class SplashScreen extends CordovaPlugin {
         final int fadeSplashScreenDuration = getFadeDuration();
         final int effectiveSplashDuration = splashscreenTime - fadeSplashScreenDuration;
 
+        shouldAutoHide = hideAfterDelay;
+
         // If the splash dialog is showing don't try to show it again
         if (splashDialog != null && splashDialog.isShowing()) {
             return;
@@ -317,7 +320,7 @@ public class SplashScreen extends CordovaPlugin {
                     final Handler handler = new Handler();
                     handler.postDelayed(new Runnable() {
                         public void run() {
-                            removeSplashScreen();
+                            if (shouldAutoHide) removeSplashScreen();
                         }
                     }, effectiveSplashDuration);
                 }


### PR DESCRIPTION
When the plugin is initialized, the splash screen is shown with an
auto-hide delay. If a subsequent call to show() comes in while the
splashscreen is visible, it will still be automatically hidden, even
though the user expectation is that it wouldn't be.

This fix tracks the "hideAfterDelay" setting of the most recent call to
show() -- and when the auto hide timer goes off, if the most recent call
to show() did not set hideAfterDelay, then the splashscreen will not be
automatically hidden.

This provides a more consistent -- and expected -- behavior based on
user action.

Fixes https://issues.apache.org/jira/browse/CB-9094