### PR TITLE
WP8: Avoid config `value` of a wrong element.

### DIFF
--- a/src/wp/SplashScreen.cs
+++ b/src/wp/SplashScreen.cs
@@ -105,6 +105,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                     XDocument configFile = XDocument.Parse(sr.ReadToEnd());
 
                     string configAutoHide = configFile.Descendants()
+                                        .Where(x => x.Name.LocalName == "preference")
                                         .Where(x => (string)x.Attribute("name") == "AutoHideSplashScreen")
                                         .Select(x => (string)x.Attribute("value"))
                                         .FirstOrDefault();
@@ -113,6 +114,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                     prefAutoHide = bool.TryParse(configAutoHide, out bVal) ? bVal : prefAutoHide;
 
                     string configDelay = configFile.Descendants()
+                                      .Where(x => x.Name.LocalName == "preference")
                                       .Where(x => (string)x.Attribute("name") == "SplashScreenDelay")
                                       .Select(x => (string)x.Attribute("value"))
                                       .FirstOrDefault();
@@ -120,6 +122,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                     prefDelay = int.TryParse(configDelay, out nVal) ? nVal : prefDelay;
 
                     string configImage = configFile.Descendants()
+                                        .Where(x => x.Name.LocalName == "preference")
                                         .Where(x => (string)x.Attribute("name") == "SplashScreen")
                                         .Select(x => (string)x.Attribute("value"))
                                         .FirstOrDefault();


### PR DESCRIPTION
If you have an element that shares the `name`, like `<feature name="SplashScreen">`, then the `value` attribute was read of that instead (since it can appear *before* the preference element). Thus, the config of `SplashScreen` preference was not settable at all.