### PR TITLE
CB-9374 Android: add SplashShowOnlyFirstTime as preference

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -88,8 +88,10 @@ public class SplashScreen extends CordovaPlugin {
 
         // Save initial orientation.
         orientation = cordova.getActivity().getResources().getConfiguration().orientation;
-
-        firstShow = false;
+       
+       if(preferences.getBoolean("SplashShowOnlyFirstTime", true)){
+              firstShow = false;
++       }
         loadSpinner();
         showSplashScreen(true);
     }


### PR DESCRIPTION
Defaults to true like before, but when changed to false this will make possible show again after navigator.app.exitApp() is call and then event resume is trigger.