### PR TITLE
Don't rotate the iPhone 6 Plus splash

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -247,8 +247,8 @@
      * landscape. In this case the image must be rotated in order to appear
      * correctly.
      */
-    BOOL isIPad = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
-    if (UIInterfaceOrientationIsLandscape(orientation) && !isIPad) {
+    CDV_iOSDevice device = [self getCurrentDevice];
+    if (UIInterfaceOrientationIsLandscape(orientation) && !device.iPhone6Plus && !device.iPad) {
         imgTransform = CGAffineTransformMakeRotation(M_PI / 2);
         imgBounds.size = CGSizeMake(imgBounds.size.height, imgBounds.size.width);
     }


### PR DESCRIPTION
The iPhone 6 Plus splash screen is already in landscape mode, so it should also be excluded from rotation like the iPad is.