### PR TITLE
CB-9977 iOS splashscreen fading doesn't work anymore when autohide is…

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -331,7 +331,12 @@
 
         float fadeDuration = fadeSplashScreenDuration == nil ? kSplashScreenDurationDefault : [fadeSplashScreenDuration floatValue];
 
-        if ((fadeSplashScreenValue == nil) || ![fadeSplashScreenValue boolValue])
+        if (fadeSplashScreenValue == nil)
+        {
+            fadeSplashScreenValue = @"true";
+        }
+
+        if (![fadeSplashScreenValue boolValue])
         {
             fadeDuration = 0;
         }
@@ -341,7 +346,7 @@
             // they mean 10 seconds, and not the meaningless 10ms
             fadeDuration *= 1000;
         }
-        
+
         if (_visible)
         {
             if (_imageView == nil)


### PR DESCRIPTION
… set to false

Fixes FadeSplashScreen to default to true
[Jira issue](https://issues.apache.org/jira/browse/CB-9977)