### PR TITLE
CB-9043 CB-10244 Fix the ios splashscreen being deformed on orientation change

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -244,10 +244,47 @@
     return imageName;
 }
 
+- (UIInterfaceOrientation)getCurrentOrientation
+{
+    UIInterfaceOrientation iOrientation = [UIApplication sharedApplication].statusBarOrientation;
+    UIDeviceOrientation dOrientation = [UIDevice currentDevice].orientation;
+
+    bool landscape;
+
+    if (dOrientation == UIDeviceOrientationUnknown || dOrientation == UIDeviceOrientationFaceUp || dOrientation == UIDeviceOrientationFaceDown) {
+        // If the device is laying down, use the UIInterfaceOrientation based on the status bar.
+        landscape = UIInterfaceOrientationIsLandscape(iOrientation);
+    } else {
+        // If the device is not laying down, use UIDeviceOrientation.
+        landscape = UIDeviceOrientationIsLandscape(dOrientation);
+
+        // There's a bug in iOS!!!! http://openradar.appspot.com/7216046
+        // So values needs to be reversed for landscape!
+        if (dOrientation == UIDeviceOrientationLandscapeLeft)
+        {
+            iOrientation = UIInterfaceOrientationLandscapeRight;
+        }
+        else if (dOrientation == UIDeviceOrientationLandscapeRight)
+        {
+            iOrientation = UIInterfaceOrientationLandscapeLeft;
+        }
+        else if (dOrientation == UIDeviceOrientationPortrait)
+        {
+            iOrientation = UIInterfaceOrientationPortrait;
+        }
+        else if (dOrientation == UIDeviceOrientationPortraitUpsideDown)
+        {
+            iOrientation = UIInterfaceOrientationPortraitUpsideDown;
+        }
+    }
+
+    return iOrientation;
+}
+
 // Sets the view's frame and image.
 - (void)updateImage
 {
-    NSString* imageName = [self getImageName:[[UIApplication sharedApplication] statusBarOrientation] delegate:(id<CDVScreenOrientationDelegate>)self.viewController device:[self getCurrentDevice]];
+    NSString* imageName = [self getImageName:[self getCurrentOrientation] delegate:(id<CDVScreenOrientationDelegate>)self.viewController device:[self getCurrentDevice]];
 
     if (![imageName isEqualToString:_curImageName])
     {

--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -318,8 +318,8 @@
      * landscape. In this case the image must be rotated in order to appear
      * correctly.
      */
-    BOOL isIPad = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
-    if (UIInterfaceOrientationIsLandscape(orientation) && !isIPad)
+    CDV_iOSDevice device = [self getCurrentDevice];
+    if (UIInterfaceOrientationIsLandscape(orientation) && !device.iPhone6Plus && !device.iPad)
     {
         imgTransform = CGAffineTransformMakeRotation(M_PI / 2);
         imgBounds.size = CGSizeMake(imgBounds.size.height, imgBounds.size.width);


### PR DESCRIPTION
Don't rotate the iPhone 6 Plus splash

Fixes 2 orientation change-related issues.

[CB-9043](https://issues.apache.org/jira/browse/CB-9043)
[CB-10244](https://issues.apache.org/jira/browse/CB-10244)