### PR TITLE
CB-9374 Android: add SplashShowOnlyFirstTime as preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ In your `config.xml`, you need to add the following preferences:
     <preference name="SplashScreen" value="foo" />
     <preference name="SplashScreenDelay" value="3000" />
     <preference name="SplashMaintainAspectRatio" value="true|false" />
+    <preference name="SplashShowOnlyFirstTime" value="true|false" />
 
 Where foo is the name of the splashscreen file, preferably a 9 patch file. Make sure to add your splashcreen files to your res/xml directory under the appropriate folders. The second parameter represents how long the splashscreen will appear in milliseconds. It defaults to 3000 ms. See [Icons and Splash Screens](http://cordova.apache.org/docs/en/edge/config_ref_images.md.html)
 for more information.
@@ -73,6 +74,8 @@ for more information.
 "SplashMaintainAspectRatio" preference is optional. If set to true, splash screen drawable is not stretched to fit screen, but instead simply "covers" the screen, like CSS "background-size:cover". This is very useful when splash screen images cannot be distorted in any way, for example when they contain scenery or text. This setting works best with images that have large margins (safe areas) that can be safely cropped on screens with different aspect ratios.
 
 The plugin reloads splash drawable whenever orientation changes, so you can specify different drawables for portrait and landscape orientations.
+
+"SplashShowOnlyFirstTime" preference is also optional and defaults to true. When set true splash screen will only appear when application launch. However, if you plan to use `navigator.app.exitApp()` to close application and force splash screen appear on next launch, you should set this property to false.
 
 ### Browser Quirks
 

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -89,7 +89,10 @@ public class SplashScreen extends CordovaPlugin {
         // Save initial orientation.
         orientation = cordova.getActivity().getResources().getConfiguration().orientation;
 
-        firstShow = false;
+        if(preferences.getBoolean("SplashShowOnlyFirstTime", true)){
+               firstShow = false;
+        }
+
         loadSpinner();
         showSplashScreen(true);
     }


### PR DESCRIPTION
"SplashShowOnlyFirstTime" preference  defaults to true. When set true splash screen will only appear when application launch. However, if you plan to use `navigator.app.exitApp()` to close application and force splash screen appear on next launch, you should set this property to false.