### PR TITLE
CB-9240 Cordova splash screen plugin iPad landscape mode issue

### DIFF
--- a/src/ios/CDVViewController+SplashScreen.m
+++ b/src/ios/CDVViewController+SplashScreen.m
@@ -35,6 +35,13 @@
 - (BOOL)enabledAutorotation
 {
     NSNumber *number =  (NSNumber *)objc_getAssociatedObject(self, @selector(enabledAutorotation));
+
+    // Defaulting to YES to correspond parent CDVViewController behavior
+    if (number == nil)
+    {
+        return YES;
+    }
+
     return [number boolValue];
 }
 


### PR DESCRIPTION
[Jira issue](https://issues.apache.org/jira/browse/CB-9240)

Aligns `shouldAutorotate` default value with [parent CDVViewController behavior](https://github.com/apache/cordova-ios/blob/d3c5519719d172bfcf6d994c740615b6fdfa91e6/CordovaLib/Classes/Public/CDVViewController.m#L352-L355).

This fix also does not break iPhone rotation behavior - it's being turned on after splashscreen hide and swizzling dismissal.