### PR TITLE
CB-9538 Implementing FadeSplashScreen feature for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can use the following preferences in your `config.xml`:
     </platform>
 
 
-### iOS Quirks
+### Android and iOS Quirks
 
 - `FadeSplashScreen` (boolean, defaults to `true`): Set to `false` to
   prevent the splash screen from fading in and out when its display
@@ -106,6 +106,24 @@ You can use the following preferences in your `config.xml`:
 
 Note also that this value used to be seconds, and not milliseconds, so values less than 30 will still be treated as seconds. ( Consider this a deprecated patch that will disapear in some future version. )
 
+_Note_: `FadeSplashScreenDuration` is included into `SplashScreenDelay`, for example if you have `<preference name="SplashScreenDelay" value="3000" />` and `<preference name="FadeSplashScreenDuration" value="1000"/>` defined in `config.xml`:
+
+- 00:00 - splashscreen is shown
+- 00:02 - fading has started
+- 00:03 - splashscreen is hidden
+
+Turning the fading off via `<preference name="FadeSplashScreen" value="false"/>` technically means fading duration to be `0` so that in this example the overall splash delay will still be 3 seconds.
+
+_Note_: This only applies to the app startup - you need to take the fading timeout into account when manually showing/hiding the splashscreen in the code:
+
+```javascript
+navigator.splashscreen.show();
+window.setTimeout(function () {
+    navigator.splashscreen.hide();
+}, splashDuration - fadeDuration);
+```
+
+### iOS Quirks
 
 - `ShowSplashScreenSpinner` (boolean, defaults to `true`): Set to `false`
   to hide the splash-screen spinner.

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -30,6 +30,9 @@ import android.view.Display;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.WindowManager;
+import android.view.animation.Animation;
+import android.view.animation.AlphaAnimation;
+import android.view.animation.DecelerateInterpolator;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
@@ -197,9 +200,39 @@ public class SplashScreen extends CordovaPlugin {
         cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
                 if (splashDialog != null && splashDialog.isShowing()) {
-                    splashDialog.dismiss();
-                    splashDialog = null;
-                    splashImageView = null;
+                    if (preferences.getBoolean("FadeSplashScreen", true)) {
+                        final int splashscreenDuration = (int)(preferences.getDouble("FadeSplashScreenDuration", 2) * 1000);
+
+                        AlphaAnimation fadeOut = new AlphaAnimation(1, 0);
+                        fadeOut.setInterpolator(new DecelerateInterpolator()); //add this
+                        fadeOut.setDuration(splashscreenDuration);
+
+                        splashImageView.setAnimation(fadeOut);
+                        splashImageView.startAnimation(fadeOut);
+
+                        fadeOut.setAnimationListener(new Animation.AnimationListener() {
+                            @Override
+                            public void onAnimationStart(Animation animation) {
+                            }
+
+                            @Override
+                            public void onAnimationEnd(Animation animation) {
+                                if (splashDialog != null && splashDialog.isShowing()) {
+                                    splashDialog.dismiss();
+                                    splashDialog = null;
+                                    splashImageView = null;
+                                }
+                            }
+
+                            @Override
+                            public void onAnimationRepeat(Animation animation) {
+                            }
+                        });
+                    } else {
+                        splashDialog.dismiss();
+                        splashDialog = null;
+                        splashImageView = null;
+                    }
                 }
             }
         });


### PR DESCRIPTION
FadeSplashScreen is supported by using AlphaAnimation to fade out the ImageView.

Based on #53 
Documented the `FadeSplashScreenDuration` preference usage.

[Jira issue](https://issues.apache.org/jira/browse/CB-9538)