### PR TITLE
CB-8396 Add AutoHideSplashScreen logic to Android's Splashscreen

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -73,7 +73,7 @@ public class SplashScreen extends CordovaPlugin {
 
     @Override
     protected void pluginInitialize() {
-        if (HAS_BUILT_IN_SPLASH_SCREEN || !firstShow) {
+        if (HAS_BUILT_IN_SPLASH_SCREEN) {
             return;
         }
         // Make WebView invisible while loading URL
@@ -93,12 +93,15 @@ public class SplashScreen extends CordovaPlugin {
         // Save initial orientation.
         orientation = cordova.getActivity().getResources().getConfiguration().orientation;
 
+        if (firstShow) {
+            boolean autoHide = preferences.getBoolean("AutoHideSplashScreen", true);
+            loadSpinner();
+            showSplashScreen(autoHide);
+        }
+
         if (preferences.getBoolean("SplashShowOnlyFirstTime", true)) {
             firstShow = false;
         }
-
-        loadSpinner();
-        showSplashScreen(true);
     }
 
     /**


### PR DESCRIPTION
[Jira issue](https://issues.apache.org/jira/browse/CB-8396)

Also initializing the splashscreen image irrespective of firstShow because the splashscreen could be shown manually via navigator.splashscreen.show(); after exiting the app using BackButton or via navigator.app.exitApp(); - otherwise the image would be uninitialized.