### PR TITLE
CB-9516 Android SplashScreen - Spinner Does Not Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ window.setTimeout(function () {
 }, splashDuration - fadeDuration);
 ```
 
-### iOS Quirks
-
 - `ShowSplashScreenSpinner` (boolean, defaults to `true`): Set to `false`
   to hide the splash-screen spinner.
 


### PR DESCRIPTION
[Jira issue](https://issues.apache.org/jira/browse/CB-9516)

Removes spinnerStop call from onMessage("spinner", "stop") as it is called when webview is shown and we are hiding spinner manually along with the splashscreen dialog.
Changed the spinner to be noncancellable.
Changed the ProgressDialog to custom only-spinner mode (on transparent background, without title/message and dimming).
Removed unused spinnerStart action handler.
Updated the docs.