### PR TITLE
CB-10692 Don't fade when plugin is forced to close

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -134,7 +134,7 @@ public class SplashScreen extends CordovaPlugin {
             return;
         }
         // hide the splash screen to avoid leaking a window
-        this.removeSplashScreen();
+        this.removeSplashScreen(true);
     }
 
     @Override
@@ -143,7 +143,7 @@ public class SplashScreen extends CordovaPlugin {
             return;
         }
         // hide the splash screen to avoid leaking a window
-        this.removeSplashScreen();
+        this.removeSplashScreen(true);
         // If we set this to true onDestroy, we lose track when we go from page to page!
         //firstShow = true;
     }
@@ -177,7 +177,7 @@ public class SplashScreen extends CordovaPlugin {
         }
         if ("splashscreen".equals(id)) {
             if ("hide".equals(data.toString())) {
-                this.removeSplashScreen();
+                this.removeSplashScreen(false);
             } else {
                 this.showSplashScreen(false);
             }
@@ -206,12 +206,13 @@ public class SplashScreen extends CordovaPlugin {
         }
     }
 
-    private void removeSplashScreen() {
+    private void removeSplashScreen(final boolean forceHideImmediately) {
         cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
                 if (splashDialog != null && splashDialog.isShowing()) {
                     final int fadeSplashScreenDuration = getFadeDuration();
-                    if (fadeSplashScreenDuration > 0) {
+                    // CB-10692 If the plugin is being paused/destroyed, skip the fading and hide it immediately
+                    if (fadeSplashScreenDuration > 0 && forceHideImmediately == false) {
                         AlphaAnimation fadeOut = new AlphaAnimation(1, 0);
                         fadeOut.setInterpolator(new DecelerateInterpolator());
                         fadeOut.setDuration(fadeSplashScreenDuration);
@@ -319,7 +320,7 @@ public class SplashScreen extends CordovaPlugin {
                     handler.postDelayed(new Runnable() {
                         public void run() {
                             if (lastHideAfterDelay) {
-                                removeSplashScreen();
+                                removeSplashScreen(false);
                             }
                         }
                     }, effectiveSplashDuration);


### PR DESCRIPTION
The fading logic exposed a race condition in an edge case when the
plugin was repeatedly reinitialized, e.g. when the WebView tries to load
a new URL. To address this, we add a flag to removeSplashScreen() that
allows the fade logic to be bypassed in certain circumstances --
specifically, when hiding the splashscreen due to onPause or onDestroy
events. By hiding it immediately in this scenario, we can avoid any race
conditions due to the fade delay.

Fixes https://issues.apache.org/jira/browse/CB-10692