### PR TITLE
[android] stop hide splash when pause

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -133,8 +133,6 @@ public class SplashScreen extends CordovaPlugin {
         if (HAS_BUILT_IN_SPLASH_SCREEN) {
             return;
         }
-        // hide the splash screen to avoid leaking a window
-        this.removeSplashScreen();
     }
 
     @Override


### PR DESCRIPTION
according to discuss in [make android support AutoHideSplashScreen](https://github.com/apache/cordova-plugin-splashscreen/pull/71)

remove the code which hiding splash when App pause.
