### PR TITLE
Transition bugfix

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -447,10 +447,13 @@
                                        [weakSelf hideViews];
                                    }
                                    completion:^(BOOL finished) {
-                                       if (finished) {
+                                       // Always destroy views, otherwise you could have an 
+                                       // invisible splashscreen that is overlayed over your active views
+                                       // which causes that no touch events are passed
+                                       //if (finished) {
                                            [weakSelf destroyViews];
                                            // TODO: It might also be nice to have a js event happen here -jm
-                                       }
+                                       //}
                                      }
                     ];
             })));


### PR DESCRIPTION
When you move the app to the background when the fade animation is happening, then the splashscreen view isn't destroyed. Which causes that no touch events are passed anymore when you resume the app. Because the splashscreen is invisible overlayed over the current view