### PR TITLE
CB-10866: Adding engine info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,13 @@
     "test": "npm run jshint",
     "jshint": "node node_modules/jshint/bin/jshint www && node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint tests"
   },
-  "engines": [
-    {
-      "name": "cordova-android",
-      "version": ">=3.6.0"
+  "engines": {
+    "cordovaDependencies": {
+      "0.3.6": {
+        "cordova-android": ">=3.6.0"
+      }
     }
-  ],
+  },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
Checked Github to see when the constraint was added (seems like version 0.3.6 ddec7008cbab13865ff1321696bfeacd577e716)