### PR TITLE
CB-11326 Prevent crash when initializing plugin after navigating to another URL

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -83,7 +83,13 @@ public class SplashScreen extends CordovaPlugin {
             return;
         }
         // Make WebView invisible while loading URL
-        getView().setVisibility(View.INVISIBLE);
+        // CB-11326 Ensure we're calling this on UI thread
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                getView().setVisibility(View.INVISIBLE);
+            }
+        });
         int drawableId = preferences.getInteger("SplashDrawableId", 0);
         if (drawableId == 0) {
             String splashResource = preferences.getString("SplashScreen", "screen");


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- Android

### What does this PR do?
Fixes app hang (due to internal crash) after calling `navigator.app.loadUrl(myurl)`

### What testing has been done on this change?
Manual testing

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.