### PR TITLE
CB-7497: (iOS) Fix bug with application crash

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -154,6 +154,7 @@
     } @catch (NSException *exception) { 
      NSLog(@"bounds observer was not attached"); 
     }
+    
 }
 
 - (CDV_iOSDevice) getCurrentDevice

--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -142,8 +142,18 @@
     _curImageName = nil;
 
     self.viewController.view.userInteractionEnabled = YES;  // re-enable user interaction upon completion
-    [self.viewController.view removeObserver:self forKeyPath:@"frame"];
-    [self.viewController.view removeObserver:self forKeyPath:@"bounds"];
+    
+    @try { 
+     [self.viewController.view removeObserver:self forKeyPath:@"frame"]; 
+    } @catch (NSException *exception) { 
+     NSLog(@"frame observer was not attached"); 
+    }
+    
+    @try { 
+     [self.viewController.view removeObserver:self forKeyPath:@"bounds"]; 
+    } @catch (NSException *exception) { 
+     NSLog(@"bounds observer was not attached"); 
+    }
 }
 
 - (CDV_iOSDevice) getCurrentDevice


### PR DESCRIPTION
### Platforms affected
iOS 

### What does this PR do?
Fix bug with application crash on attempt to remove observers from viewController

### What testing has been done on this change?
Tested on iOS 9.3.2 with File (affected) plugin. An application does not crash anymore.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

