### PR TITLE
Fix crash on iOS when reloading page from remote Safari

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -77,7 +77,7 @@
     BOOL autorotateValue = (device.iPad || device.iPhone6Plus) ?
         [(CDVViewController *)self.viewController shouldAutorotateDefaultValue] :
         NO;
-    
+
     [(CDVViewController *)self.viewController setEnabledAutorotation:autorotateValue];
 
     NSString* topActivityIndicator = [self.commandDelegate.settings objectForKey:[@"TopActivityIndicator" lowercaseString]];
@@ -142,20 +142,28 @@
     _curImageName = nil;
 
     self.viewController.view.userInteractionEnabled = YES;  // re-enable user interaction upon completion
-    [self.viewController.view removeObserver:self forKeyPath:@"frame"];
-    [self.viewController.view removeObserver:self forKeyPath:@"bounds"];
+    @try {
+        [self.viewController.view removeObserver:self forKeyPath:@"frame"];
+        [self.viewController.view removeObserver:self forKeyPath:@"bounds"];
+    }
+    @catch (NSException *exception) {
+        // When reloading the page from a remotely connected Safari, there
+        // are no observers, so the removeObserver method throws an exception,
+        // that we can safely ignore.
+        // Alternatively we can check whether there are observers before calling removeObserver
+    }
 }
 
 - (CDV_iOSDevice) getCurrentDevice
 {
     CDV_iOSDevice device;
-    
+
     UIScreen* mainScreen = [UIScreen mainScreen];
     CGFloat mainScreenHeight = mainScreen.bounds.size.height;
     CGFloat mainScreenWidth = mainScreen.bounds.size.width;
-    
+
     int limit = MAX(mainScreenHeight,mainScreenWidth);
-    
+
     device.iPad = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
     device.iPhone = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone);
     device.retina = ([mainScreen scale] == 2.0);
@@ -166,7 +174,7 @@
     // this is appropriate for detecting the runtime screen environment
     device.iPhone6 = (device.iPhone && limit == 667.0);
     device.iPhone6Plus = (device.iPhone && limit == 736.0);
-    
+
     return device;
 }
 
@@ -174,15 +182,15 @@
 {
     // Use UILaunchImageFile if specified in plist.  Otherwise, use Default.
     NSString* imageName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UILaunchImageFile"];
-    
+
     NSUInteger supportedOrientations = [orientationDelegate supportedInterfaceOrientations];
-    
+
     // Checks to see if the developer has locked the orientation to use only one of Portrait or Landscape
     BOOL supportsLandscape = (supportedOrientations & UIInterfaceOrientationMaskLandscape);
     BOOL supportsPortrait = (supportedOrientations & UIInterfaceOrientationMaskPortrait || supportedOrientations & UIInterfaceOrientationMaskPortraitUpsideDown);
     // this means there are no mixed orientations in there
     BOOL isOrientationLocked = !(supportsPortrait && supportsLandscape);
-    
+
     if (imageName)
     {
         imageName = [imageName stringByDeletingPathExtension];
@@ -251,7 +259,7 @@
                 case UIInterfaceOrientationLandscapeRight:
                     imageName = [imageName stringByAppendingString:@"-Landscape"];
                     break;
-                    
+
                 case UIInterfaceOrientationPortrait:
                 case UIInterfaceOrientationPortraitUpsideDown:
                 default:
@@ -260,7 +268,7 @@
             }
         }
     }
-    
+
     return imageName;
 }
 
@@ -457,7 +465,7 @@
                                         [weakSelf hideViews];
                                     }
                                     completion:^(BOOL finished) {
-                                        // Always destroy views, otherwise you could have an 
+                                        // Always destroy views, otherwise you could have an
                                         // invisible splashscreen that is overlayed over your active views
                                         // which causes that no touch events are passed
                                         if (!_destroyed) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Fix a crash when calling navigator.splashscreen.hide() after reloading the page from a remote Safari

### What testing has been done on this change?
- Create an application with AutoHideSplashScreen set to false
- Call navigator.splashscreen.hide() from the application
- Connect Safari from a Mac to debug the application
- Hit the reload button from Safari
- Without this patch, the application crashes
- With this patch, the page is reloaded without any problem

### Checklist
- [ ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

