### PR TITLE
fixing problem when trying to remove splash screen

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -216,7 +216,7 @@ public class SplashScreen extends CordovaPlugin {
     private void removeSplashScreen(final boolean forceHideImmediately) {
         cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
-                if (splashDialog != null && splashDialog.isShowing()) {
+                if (splashDialog != null && splashDialog.isShowing() && splashImageView != null) {
                     final int fadeSplashScreenDuration = getFadeDuration();
                     // CB-10692 If the plugin is being paused/destroyed, skip the fading and hide it immediately
                     if (fadeSplashScreenDuration > 0 && forceHideImmediately == false) {


### PR DESCRIPTION
I get an java.lang.NullpointerException in the removeSplashScreen method. I am new to this Plugin and not able to describe why this happens. I think there are multiple instances of the SplashScreen, and the splashDialog is set, but the splashDialogView is null. Thats why I made this change and now it works for me, no Exceptions any more. Can you please check this?
