### PR TITLE
CB-12011: (android) added the possibility to change the spinner color…

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ In your `config.xml`, you can add the following preferences:
 ```xml
 <preference name="SplashMaintainAspectRatio" value="true|false" />
 <preference name="SplashShowOnlyFirstTime" value="true|false" />
+<preference name="SplashScreenSpinnerColor" value="white" />
 ```
 
 "SplashMaintainAspectRatio" preference is optional. If set to true, splash screen drawable is not stretched to fit screen, but instead simply "covers" the screen, like CSS "background-size:cover". This is very useful when splash screen images cannot be distorted in any way, for example when they contain scenery or text. This setting works best with images that have large margins (safe areas) that can be safely cropped on screens with different aspect ratios.
@@ -409,6 +410,8 @@ In your `config.xml`, you can add the following preferences:
 The plugin reloads splash drawable whenever orientation changes, so you can specify different drawables for portrait and landscape orientations.
 
 "SplashShowOnlyFirstTime" preference is also optional and defaults to `true`. When set to `true` splash screen will only appear on application launch. However, if you plan to use `navigator.app.exitApp()` to close application and force splash screen appear on next launch, you should set this property to `false` (this also applies to closing the App with Back button).
+
+"SplashScreenSpinnerColor" preference is also optional and is ignored when not set. Setting it to a valid color name or HEX color code will change the color of the spinner on Android 5.0+ devices.
 
 ### Browser Quirks
 

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -361,27 +361,27 @@ public class SplashScreen extends CordovaPlugin {
                 RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
                 layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
                 progressBar.setLayoutParams(layoutParams);
-				
-				if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-					String colorName = preferences.getString("SplashScreenSpinnerColor", null);
-					if(colorName != null){
-						int[][] states = new int[][] {
-							new int[] { android.R.attr.state_enabled}, // enabled
-							new int[] {-android.R.attr.state_enabled}, // disabled
-							new int[] {-android.R.attr.state_checked}, // unchecked
-							new int[] { android.R.attr.state_pressed}  // pressed
-						};
-						int progressBarColor = Color.parseColor(colorName);
-						int[] colors = new int[] {
-							progressBarColor,
-							progressBarColor,
-							progressBarColor,
-							progressBarColor
-						};
-						ColorStateList colorStateList = new ColorStateList(states, colors);             
-						progressBar.setIndeterminateTintList(colorStateList);
-					}
-				}
+
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                    String colorName = preferences.getString("SplashScreenSpinnerColor", null);
+                    if(colorName != null){
+                        int[][] states = new int[][] {
+                            new int[] { android.R.attr.state_enabled}, // enabled
+                            new int[] {-android.R.attr.state_enabled}, // disabled
+                            new int[] {-android.R.attr.state_checked}, // unchecked
+                            new int[] { android.R.attr.state_pressed}  // pressed
+                        };
+                        int progressBarColor = Color.parseColor(colorName);
+                        int[] colors = new int[] {
+                            progressBarColor,
+                            progressBarColor,
+                            progressBarColor,
+                            progressBarColor
+                        };
+                        ColorStateList colorStateList = new ColorStateList(states, colors);
+                        progressBar.setIndeterminateTintList(colorStateList);
+                    }
+                }
 
                 centeredLayout.addView(progressBar);
 

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -24,6 +24,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Configuration;
+import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Handler;
@@ -360,6 +361,27 @@ public class SplashScreen extends CordovaPlugin {
                 RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
                 layoutParams.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
                 progressBar.setLayoutParams(layoutParams);
+				
+				if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+					String colorName = preferences.getString("SplashScreenSpinnerColor", null);
+					if(colorName != null){
+						int[][] states = new int[][] {
+							new int[] { android.R.attr.state_enabled}, // enabled
+							new int[] {-android.R.attr.state_enabled}, // disabled
+							new int[] {-android.R.attr.state_checked}, // unchecked
+							new int[] { android.R.attr.state_pressed}  // pressed
+						};
+						int progressBarColor = Color.parseColor(colorName);
+						int[] colors = new int[] {
+							progressBarColor,
+							progressBarColor,
+							progressBarColor,
+							progressBarColor
+						};
+						ColorStateList colorStateList = new ColorStateList(states, colors);             
+						progressBar.setIndeterminateTintList(colorStateList);
+					}
+				}
 
                 centeredLayout.addView(progressBar);
 


### PR DESCRIPTION
### Platforms affected

Android
### What does this PR do?

It adds the possibility to change the spinner color from the config.xml file for android 5.0+ apps.
Example config.xml line:
&lt;preference name="SplashScreenSpinnerColor" value="white"/>
Color names as well as hex colors can be used.
### What testing has been done on this change?

Tested the updated Splashscreen.java in an ionic 2 app. The splashscreen works and shows the spinner in the color that was defined in the config.xml
### Checklist
- [x ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x ] Added automated test coverage as appropriate for this change.
