### PR TITLE
fix(ios): Fix crash when listening for KVO changes for deallocated object (CB-12062)

### DIFF
--- a/tests/ios/CDVSplashScreenTest/CDVSplashScreenLibTests/TestCDVSplashScreen.h
+++ b/tests/ios/CDVSplashScreenTest/CDVSplashScreenLibTests/TestCDVSplashScreen.h
@@ -1,0 +1,26 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "CDVSplashScreen.h"
+
+@interface TestCDVSplashScreen : CDVSplashScreen
+
+@property(nonatomic, assign) BOOL updateImageCalled;
+
+@end

--- a/tests/ios/CDVSplashScreenTest/CDVSplashScreenLibTests/TestCDVSplashScreen.m
+++ b/tests/ios/CDVSplashScreenTest/CDVSplashScreenLibTests/TestCDVSplashScreen.m
@@ -1,0 +1,28 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import "TestCDVSplashScreen.h"
+
+@implementation TestCDVSplashScreen
+
+- (void)updateImage {
+    self.updateImageCalled = YES;
+}
+
+@end

--- a/tests/ios/CDVSplashScreenTest/CDVSplashScreenLibTests/ViewFrameObservingTest.m
+++ b/tests/ios/CDVSplashScreenTest/CDVSplashScreenLibTests/ViewFrameObservingTest.m
@@ -1,0 +1,89 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import <UIKit/UIKit.h>
+#import "CDVSplashScreen.h"
+#import <Cordova/CDVViewController.h>
+#import "TestCDVSplashScreen.h"
+
+@interface ViewFrameObservingTest : XCTestCase
+@property (nonatomic, strong) CDVSplashScreen* plugin;
+@end
+
+@interface CDVSplashScreen (Private)
+
+- (void)createViews;
+- (void)destoyViews;
+
+@end
+
+@interface CDVTestViewController : UIViewController // CDVViewController
+@property (nonatomic, assign) BOOL enabledAutorotation;
+@property (nonatomic, readonly) BOOL shouldAutorotateDefaultValue;
+@end
+
+@implementation CDVTestViewController
+@end
+
+@implementation ViewFrameObservingTest
+
+- (void)setUp {
+    [super setUp];
+    self.plugin = [[CDVSplashScreen alloc] init];
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+    self.plugin = nil;
+}
+
+- (void)testCorrectKVOObservingRemoval {
+    XCTAssertNoThrow([self kvoExample]);
+}
+
+- (void)testCorrectKVOObservingOfView {
+    TestCDVSplashScreen * testPlugin = [[TestCDVSplashScreen alloc] init];
+    self.plugin = testPlugin;
+    CDVTestViewController * controller = [CDVTestViewController new];
+
+    self.plugin.viewController = controller;
+    [self.plugin createViews];
+    XCTAssertTrue(testPlugin.updateImageCalled, @"Should update image right after views creation");
+
+    testPlugin.updateImageCalled = NO;
+    controller.view.frame = CGRectMake(0,0,100,100);
+    XCTAssertTrue(testPlugin.updateImageCalled, @"Should update image when view frame changes");
+
+    testPlugin.updateImageCalled = NO;
+    controller.view.bounds = CGRectMake(0,0,100,100);
+    XCTAssertTrue(testPlugin.updateImageCalled, @"Should update image when view bounds changes");
+}
+
+
+- (void)kvoExample {
+    @autoreleasepool {
+        CDVTestViewController * controller = [CDVTestViewController new];
+        self.plugin.viewController = controller;
+        [self.plugin createViews];
+    }
+}
+
+@end

--- a/tests/ios/CDVSplashScreenTest/CDVSplashScreenTest.xcodeproj/project.pbxproj
+++ b/tests/ios/CDVSplashScreenTest/CDVSplashScreenTest.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		7E9F51B819DA14FD00DA31AC /* ImageNameTestDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E9F51B719DA14FD00DA31AC /* ImageNameTestDelegates.m */; };
 		7E9F51B919DA1B1600DA31AC /* libCDVSplashScreenLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E9F519519DA102000DA31AC /* libCDVSplashScreenLib.a */; };
 		7E9F51BA19DA1B2000DA31AC /* libCordova.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E9F519019DA0F8300DA31AC /* libCordova.a */; };
+		E45AF2771DBF974D000C5AFE /* ViewFrameObservingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E45AF2761DBF974D000C5AFE /* ViewFrameObservingTest.m */; };
+		E45AF27D1DBFA4D0000C5AFE /* TestCDVSplashScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = E45AF27C1DBFA4D0000C5AFE /* TestCDVSplashScreen.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +66,9 @@
 		7E9F51B419DA127E00DA31AC /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		7E9F51B619DA12C600DA31AC /* ImageNameTestDelegates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageNameTestDelegates.h; sourceTree = "<group>"; };
 		7E9F51B719DA14FD00DA31AC /* ImageNameTestDelegates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ImageNameTestDelegates.m; sourceTree = "<group>"; };
+		E45AF2761DBF974D000C5AFE /* ViewFrameObservingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewFrameObservingTest.m; sourceTree = "<group>"; };
+		E45AF27B1DBFA4D0000C5AFE /* TestCDVSplashScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestCDVSplashScreen.h; sourceTree = "<group>"; };
+		E45AF27C1DBFA4D0000C5AFE /* TestCDVSplashScreen.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestCDVSplashScreen.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +138,9 @@
 				7E9F51B019DA114400DA31AC /* ImageNameTest.m */,
 				7E9F51B619DA12C600DA31AC /* ImageNameTestDelegates.h */,
 				7E9F51B719DA14FD00DA31AC /* ImageNameTestDelegates.m */,
+				E45AF2761DBF974D000C5AFE /* ViewFrameObservingTest.m */,
+				E45AF27B1DBFA4D0000C5AFE /* TestCDVSplashScreen.h */,
+				E45AF27C1DBFA4D0000C5AFE /* TestCDVSplashScreen.m */,
 			);
 			path = CDVSplashScreenLibTests;
 			sourceTree = "<group>";
@@ -257,7 +265,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E45AF27D1DBFA4D0000C5AFE /* TestCDVSplashScreen.m in Sources */,
 				7E9F51B119DA114400DA31AC /* ImageNameTest.m in Sources */,
+				E45AF2771DBF974D000C5AFE /* ViewFrameObservingTest.m in Sources */,
 				7E9F51B819DA14FD00DA31AC /* ImageNameTestDelegates.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
### Platforms affected

ios
### What does this PR do?

Fix crash when listening for KVO changes for deallocated object
### What testing has been done on this change?

Tests aded
### Checklist
- ✅ [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- ✅ Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- ✅ Added automated test coverage as appropriate for this change.
