### PR TITLE
CB-11602 Splashscreen plugin receives onPause and hides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-splashscreen",
-  "version": "4.0.2-dev",
+  "version": "5.0.0-dev",
   "description": "Cordova Splashscreen Plugin",
   "cordova": {
     "id": "cordova-plugin-splashscreen",
@@ -48,6 +48,10 @@
         "cordova-windows": ">=4.4.0"
       },
       "5.0.0": {
+        "cordova-android": ">=6.2.0",
+        "cordova-windows": ">=4.4.0"
+      },
+      "6.0.0": {
         "cordova": ">100"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-splashscreen"
-      version="4.0.2-dev">
+      version="5.0.0-dev">
     <name>Splashscreen</name>
     <description>Cordova Splashscreen Plugin</description>
     <license>Apache 2.0</license>
@@ -29,7 +29,7 @@
     <issue>https://issues.apache.org/jira/browse/CB/component/12320653</issue>
 
     <engines>
-        <engine name="cordova-android" version=">=3.6.0" /><!-- Requires CordovaPlugin.preferences -->
+        <engine name="cordova-android" version=">=6.2.0" /><!-- Requires CordovaPlugin.preferences, onRestart -->
         <engine name="cordova-windows" version=">=4.4.0" />
     </engines>
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Save splashscreen state and restore it in onRestart event
Requires https://github.com/apache/cordova-android/pull/353

### What testing has been done on this change?
Manual testing, plugin auto and manual tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
