### PR TITLE
CB-12099 (android) SplashScreen Screen Flicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,13 +435,16 @@ In your `config.xml`, you can add the following preferences:
 ```xml
 <preference name="SplashMaintainAspectRatio" value="true|false" />
 <preference name="SplashShowOnlyFirstTime" value="true|false" />
+<preference name="SplashScreenBackgroundColor" value="0xFFFFFFFF"/>
 ```
 
-"SplashMaintainAspectRatio" preference is optional. If set to true, splash screen drawable is not stretched to fit screen, but instead simply "covers" the screen, like CSS "background-size:cover". This is very useful when splash screen images cannot be distorted in any way, for example when they contain scenery or text. This setting works best with images that have large margins (safe areas) that can be safely cropped on screens with different aspect ratios.
+- `SplashMaintainAspectRatio` preference is optional. If set to true, splash screen drawable is not stretched to fit screen, but instead simply "covers" the screen, like CSS "background-size:cover". This is very useful when splash screen images cannot be distorted in any way, for example when they contain scenery or text. This setting works best with images that have large margins (safe areas) that can be safely cropped on screens with different aspect ratios.
 
 The plugin reloads splash drawable whenever orientation changes, so you can specify different drawables for portrait and landscape orientations.
 
-"SplashShowOnlyFirstTime" preference is also optional and defaults to `true`. When set to `true` splash screen will only appear on application launch. However, if you plan to use `navigator.app.exitApp()` to close application and force splash screen appear on next launch, you should set this property to `false` (this also applies to closing the App with Back button).
+- `SplashShowOnlyFirstTime` preference is also optional and defaults to `true`. When set to `true` splash screen will only appear on application launch. However, if you plan to use `navigator.app.exitApp()` to close application and force splash screen appear on next launch, you should set this property to `false` (this also applies to closing the App with Back button).
+
+- `SplashScreenBackgroundColor` (string, defaults to `#FFC8C8C8`): hex notation. Can be used for transparent splash screen images. `BackgroundColor` will be used if `SplashScreenBackgroundColor` not specified. `Color.BLACK` will be used if none of the above is set.
 
 ### Browser Quirks
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-splashscreen",
-  "version": "4.0.2-dev",
+  "version": "4.1.0-dev",
   "description": "Cordova Splashscreen Plugin",
   "cordova": {
     "id": "cordova-plugin-splashscreen",

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-splashscreen"
-      version="4.0.2-dev">
+      version="4.1.0-dev">
     <name>Splashscreen</name>
     <description>Cordova Splashscreen Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -53,6 +53,7 @@ public class SplashScreen extends CordovaPlugin {
     private static final boolean HAS_BUILT_IN_SPLASH_SCREEN = Integer.valueOf(CordovaWebView.CORDOVA_VERSION.split("\\.")[0]) < 4;
     private static final int DEFAULT_SPLASHSCREEN_DURATION = 3000;
     private static final int DEFAULT_FADE_DURATION = 500;
+    private static final int DEFAULT_SPLASH_BG_COLOR = Color.parseColor("#ffc8c8c8");
     private static Dialog splashDialog;
     private static ProgressDialog spinnerDialog;
     private static boolean firstShow = true;
@@ -293,8 +294,14 @@ public class SplashScreen extends CordovaPlugin {
                 splashImageView.setMinimumHeight(display.getHeight());
                 splashImageView.setMinimumWidth(display.getWidth());
 
-                // TODO: Use the background color of the webView's parent instead of using the preference.
-                splashImageView.setBackgroundColor(preferences.getInteger("backgroundColor", Color.BLACK));
+                int bgColor;
+                if (preferences.contains("SplashScreenBackgroundColor")) {
+                    bgColor = preferences.getInteger("SplashScreenBackgroundColor", DEFAULT_SPLASH_BG_COLOR);
+                } else {
+                    // Fallback to previous behavior for older platform versions:
+                    bgColor = preferences.getInteger("BackgroundColor", Color.BLACK);
+                }
+                splashImageView.setBackgroundColor(bgColor);
 
                 if (isMaintainAspectRatio()) {
                     // CENTER_CROP scale mode is equivalent to CSS "background-size:cover"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Documented new SplashScreenBackgroundColor preference
Minor version bump
Requires https://github.com/apache/cordova-android/pull/354 to use `SplashScreenBackgroundColor`; will fallback to `BackgroundColor` (and to BLACK if it's not set) otherwise.

### What testing has been done on this change?
Manual tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
