### PR TITLE
CB-12626: (android) Fix crash on Samsung devices and splash screen not showing on some other devices

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -98,7 +98,7 @@ public class SplashScreen extends CordovaPlugin {
                 if (drawableId == 0) {
                     drawableId = cordova.getActivity().getResources().getIdentifier(splashResource, "drawable", cordova.getActivity().getPackageName());
                 }
-                preferences.set("SplashDrawableId", drawableId);
+                //preferences.set("SplashDrawableId", drawableId);
             }
         }
 

--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -77,6 +77,18 @@ public class SplashScreen extends CordovaPlugin {
         }
     }
 
+    private int getSplashId() {
+        int drawableId = 0;
+        String splashResource = preferences.getString("SplashScreen", "screen");
+        if (splashResource != null) {
+            drawableId = cordova.getActivity().getResources().getIdentifier(splashResource, "drawable", cordova.getActivity().getClass().getPackage().getName());
+            if (drawableId == 0) {
+                drawableId = cordova.getActivity().getResources().getIdentifier(splashResource, "drawable", cordova.getActivity().getPackageName());
+            }
+        }
+        return drawableId;
+    }
+
     @Override
     protected void pluginInitialize() {
         if (HAS_BUILT_IN_SPLASH_SCREEN) {
@@ -90,17 +102,7 @@ public class SplashScreen extends CordovaPlugin {
                 getView().setVisibility(View.INVISIBLE);
             }
         });
-        int drawableId = preferences.getInteger("SplashDrawableId", 0);
-        if (drawableId == 0) {
-            String splashResource = preferences.getString("SplashScreen", "screen");
-            if (splashResource != null) {
-                drawableId = cordova.getActivity().getResources().getIdentifier(splashResource, "drawable", cordova.getActivity().getClass().getPackage().getName());
-                if (drawableId == 0) {
-                    drawableId = cordova.getActivity().getResources().getIdentifier(splashResource, "drawable", cordova.getActivity().getPackageName());
-                }
-                //preferences.set("SplashDrawableId", drawableId);
-            }
-        }
+        int drawableId = getSplashId();
 
         // Save initial orientation.
         orientation = cordova.getActivity().getResources().getConfiguration().orientation;
@@ -205,7 +207,7 @@ public class SplashScreen extends CordovaPlugin {
 
             // Splash drawable may change with orientation, so reload it.
             if (splashImageView != null) {
-                int drawableId = preferences.getInteger("SplashDrawableId", 0);
+                int drawableId = getSplashId();
                 if (drawableId != 0) {
                     splashImageView.setImageDrawable(cordova.getActivity().getResources().getDrawable(drawableId));
                 }
@@ -263,7 +265,7 @@ public class SplashScreen extends CordovaPlugin {
     @SuppressWarnings("deprecation")
     private void showSplashScreen(final boolean hideAfterDelay) {
         final int splashscreenTime = preferences.getInteger("SplashScreenDelay", DEFAULT_SPLASHSCREEN_DURATION);
-        final int drawableId = preferences.getInteger("SplashDrawableId", 0);
+        final int drawableId = getSplashId();
 
         final int fadeSplashScreenDuration = getFadeDuration();
         final int effectiveSplashDuration = Math.max(0, splashscreenTime - fadeSplashScreenDuration);


### PR DESCRIPTION
### Platforms affected

Android, all versions.

### What does this PR do?

This PR drops the strategy of relying on the app preferences to store the `drawableId` for the splash screen. This approach causes crashes on Samsung devices and prevents the splash screen from working correctly on some other devices.

### What testing has been done on this change?

This change has been tested on all devices reported in the JIRA issue:

- Samsung Galaxy 7 Edge, Android 7.0
- Samsung Galaxy Note 4, Android 6.0.1
- Lenovo/Zuk Z1, Android 5.1.1
- Official Android Emulator with Nexus S simulated hardware, API 25

### Checklist

- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.