### PR TITLE
Fix CB-12947 (incorrect documentation of iPhone 5 and 5s resolution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ If you choose to use legacy launch images, you will use the following syntax in 
 
 Technically the filename for the `src` attribute can be anything you want; the filenames are used because they match what will be used when your project is compiled. The width and height attributes determine which launch images are displayed on which devices as follows:
 
-|    width    |    height    |    device (orientation)   |
-|:-----------:|:------------:|:-------------------------:|
+|    width    |    height    |    device (orientation)          |
+|:-----------:|:------------:|:--------------------------------:|
 |     320     |      480     | All non-retina iPhones and iPods |
-|     640     |      960     | iPhone 4/4s/5/5s (portrait)      |
+|     640     |      960     | iPhone 4/4s (portrait)           |
+|     640     |     1136     | iPhone 5/5s/SE (portrait)        |
 |     750     |     1334     | iPhone 6/6s/7 (portrait)         |
 |    1242     |     2208     | iPhone 6+/6s+/7+ (portrait)      |
 |    2208     |     1242     | iPhone 6+/6s+/7+ (landscape)     |


### PR DESCRIPTION
iPhone 5, 5s, and SE have resolution 640x1136, not 640x960 as currently documented.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.