### PR TITLE
CB-13094: (android) Don't show splash when activity being finished

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -270,6 +270,10 @@ public class SplashScreen extends CordovaPlugin {
 
         lastHideAfterDelay = hideAfterDelay;
 
+        // Prevent to show the splash dialog if the activity is in the process of finishing
+        if (cordova.getActivity().isFinishing()) {
+            return;
+        }
         // If the splash dialog is showing don't try to show it again
         if (splashDialog != null && splashDialog.isShowing()) {
             return;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- android

### What does this PR do?
- Prevent to show the splash dialog if the activity is in the process of finishing referenced to ([android docs](https://developer.android.com/reference/android/app/Activity.html#isFinishing()))


### What testing has been done on this change?
- build and runtime is ok 
- I think there are not need special tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
