### PR TITLE
CB-13396: (ios) Fix image sizing on iPhone X

### DIFF
--- a/src/ios/CDVSplashScreen.m
+++ b/src/ios/CDVSplashScreen.m
@@ -352,7 +352,15 @@
     if ([self isUsingCDVLaunchScreen]) {
         // CB-9762's launch screen expects the image to fill the screen and be scaled using AspectFill.
         CGSize viewportSize = [UIApplication sharedApplication].delegate.window.bounds.size;
-        _imageView.frame = CGRectMake(0, 0, viewportSize.width, viewportSize.height);
+        CGFloat imageHeight = viewportSize.height;
+        
+        // make LaunchStoryboard bottom space constraint work with iOS 11 safe areas
+        if (@available(iOS 11.0, *)) {
+            UIEdgeInsets safeAreaInsets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+            imageHeight -= safeAreaInsets.bottom;
+        }
+        
+        _imageView.frame = CGRectMake(0, 0, viewportSize.width, imageHeight);
         _imageView.contentMode = UIViewContentModeScaleAspectFill;
         return; 
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS11 / iPhone X

### What does this PR do?

Prevent splash image from jumping around when CDVLaunchScreen.storyboard transitions to CDVSplashScreen.

### What testing has been done on this change?

Tested in these simulators:
- iPhone 6s / iOS 9.3
- iPhone 7 Plus / iOS 10.3
- iPhone 8 / iOS 11.0
- iPhone X / iOS 11.0

And on one device:
- iPhone 7 / iOS 11.0.1

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
