### PR TITLE
CB-13460: Apply Android style to the splash screen

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -312,8 +312,17 @@ public class SplashScreen extends CordovaPlugin {
                     splashImageView.setScaleType(ImageView.ScaleType.FIT_XY);
                 }
 
-                // Create and show the dialog
-                splashDialog = new Dialog(context, android.R.style.Theme_Translucent_NoTitleBar);
+                // Create and show the dialog.
+                // Use SplashScreenStyle if defined. If not, fall back to the default Theme_Transcluent_NoTitleBar.
+                int splashScreenStyle = cordova.getActivity()
+                    .getResources()
+                    .getIdentifier("SplashScreenStyle", "style", cordova.getActivity().getPackageName());
+
+                if (splashScreenStyle == 0) {
+                    splashDialog = new Dialog(context, android.R.style.Theme_Translucent_NoTitleBar);
+                } else {
+                    splashDialog = new Dialog(context, splashScreenStyle);
+                }
                 // check to see if the splash screen should be full screen
                 if ((cordova.getActivity().getWindow().getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN)
                         == WindowManager.LayoutParams.FLAG_FULLSCREEN) {


### PR DESCRIPTION
This change makes the splash screen dialog use the `SplashScreenStyle`, if defined.
If not, it falls back to the default style (backward compatibility).

This is conflicting with the approach in #124 but I believe the Android Style solution is more robust.

Examples:
In the `config.xml`:
```
<resource-file src="my-android-theme.xml" target="res/values/themes.xml" />
```

In the `my-android-theme.xml`:
```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <style name="SplashScreenStyle">
        <item name="android:windowFullscreen">true</item>
        <item name="android:windowTranslucentNavigation">true</item>
    </style>
</resources>
```

![image](https://user-images.githubusercontent.com/4712360/31705508-f67debcc-b3e5-11e7-980c-78cf34c0ca76.png)
```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <style name="SplashScreenStyle">
        <item name="android:statusBarColor">@android:color/holo_green_light</item>
        <item name="android:navigationBarColor">@android:color/holo_green_light</item>    
    </style>
</resources>
```

![image](https://user-images.githubusercontent.com/4712360/31705544-1b3f50fe-b3e6-11e7-9440-2cf7cd003fdb.png)