### PR TITLE
CB-13750: Add build-tools-26.0.2 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
       components:
       - tools
       - extra-android-m2repository
+      - build-tools-26.0.2
   - env: PLATFORM=android-5.1
     os: linux
     language: android
@@ -56,6 +57,7 @@ matrix:
       components:
       - tools
       - extra-android-m2repository
+      - build-tools-26.0.2
   - env: PLATFORM=android-6.0
     os: linux
     language: android
@@ -64,6 +66,7 @@ matrix:
       components:
       - tools
       - extra-android-m2repository
+      - build-tools-26.0.2
   - env: PLATFORM=android-7.0
     os: linux
     language: android
@@ -72,6 +75,7 @@ matrix:
       components:
       - tools
       - extra-android-m2repository
+      - build-tools-26.0.2
 before_install:
 - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
   && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
travis

### What does this PR do?
Add build-tools-26.0.2 so travis doesn't complain about unaccepted licenses

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
