### PR TITLE
CB-12277: (android) avoid NullPointerException  when removing splash-screen

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -219,7 +219,7 @@ public class SplashScreen extends CordovaPlugin {
     private void removeSplashScreen(final boolean forceHideImmediately) {
         cordova.getActivity().runOnUiThread(new Runnable() {
             public void run() {
-                if (splashDialog != null && splashDialog.isShowing()) {
+        if (splashDialog != null && splashImageView != null && splashDialog.isShowing()) {//check for non-null splashImageView, see https://issues.apache.org/jira/browse/CB-12277
                     final int fadeSplashScreenDuration = getFadeDuration();
                     // CB-10692 If the plugin is being paused/destroyed, skip the fading and hide it immediately
                     if (fadeSplashScreenDuration > 0 && forceHideImmediately == false) {
@@ -238,7 +238,7 @@ public class SplashScreen extends CordovaPlugin {
 
                             @Override
                             public void onAnimationEnd(Animation animation) {
-                                if (splashDialog != null && splashDialog.isShowing()) {
+                                if (splashDialog != null && splashImageView != null && splashDialog.isShowing()) {//check for non-null splashImageView, see https://issues.apache.org/jira/browse/CB-12277
                                     splashDialog.dismiss();
                                     splashDialog = null;
                                     splashImageView = null;


### PR DESCRIPTION

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android

### What does this PR do?

Avoids NullPointerException when removing splash-screen.

As described in the issue [CB-12277](https://issues.apache.org/jira/browse/CB-12277), this problem does not occur determinstically, but only sometimes.

### What testing has been done on this change?

manual testing as described in comments of issue [CB-12277](https://issues.apache.org/jira/browse/CB-12277), as there is no interface in the test-harness yet for automatically restarting apps.

the manual procedure was as follows:
 * start app, wait for splash-screen to disappear, restart app immediately
 * without patch, the NullPointerException always occurred within 5 repeats of this procedure
 * with patch, the NullPointerExeption did not occur within 20 repeats

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- ~~[ ] Added automated test coverage as appropriate for this change.~~
