### PR TITLE
[browser] Move check for showSplashScreen outside of showAndHide

### DIFF
--- a/src/browser/SplashScreenProxy.js
+++ b/src/browser/SplashScreenProxy.js
@@ -138,13 +138,11 @@ function readPreferencesFromCfg(cfg) {
  * Shows and hides splashscreen if it is enabled, with a delay according the current preferences.
  */
 function showAndHide() {
-    if(showSplashScreen) {
-        SplashScreen.show();
+    SplashScreen.show();
 
-        window.setTimeout(function() {
-            SplashScreen.hide();
-        }, splashScreenDelay);
-    }
+    window.setTimeout(function() {
+        SplashScreen.hide();
+    }, splashScreenDelay);
 }
 
 /**
@@ -153,10 +151,12 @@ function showAndHide() {
 (function initAndShow() {
     configHelper.readConfig(function(config) {
         readPreferencesFromCfg(config);
-        if (autoHideSplashScreen) {
-            showAndHide();
-        } else {
-            SplashScreen.show();
+        if (showSplashScreen) {
+            if (autoHideSplashScreen) {
+                showAndHide();
+            } else {
+                SplashScreen.show();
+            }
         }
 
     }, function(err) {

--- a/src/browser/SplashScreenProxy.js
+++ b/src/browser/SplashScreenProxy.js
@@ -135,7 +135,7 @@ function readPreferencesFromCfg(cfg) {
 }
 
 /**
- * Shows and hides splashscreen if it is enabled, with a delay according the current preferences.
+  * Shows and hides splashscreen, with a delay according the current preferences.
  */
 function showAndHide() {
     SplashScreen.show();


### PR DESCRIPTION
Currently, unless AutoHideSplashScreen is enabled in the config, not showing the splash screen is ignored altogether.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Browser

### What does this PR do?
Properly doesn't show the splash on Browser when `ShowSplashScreen` is false, even if you do not set
`AutoHideSplashScreen` to true.

### What testing has been done on this change?
Verified that plugin works as expected.