### PR TITLE
Revert Paramedic Dev Branch Usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_install:
   - if [[ "$PLATFORM" =~ local ]]; then npm install -g ios-deploy; fi
   - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
   
-  - npm install -g github:apache/cordova-paramedic\#erisu-config-test
+  - npm install -g github:apache/cordova-paramedic
   - PARAMEDIC_BUILDNAME=travis-plugin-splashscreen-$TRAVIS_JOB_NUMBER
 
   - npm install -g cordova


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Revert the usage of a dev branch of paramedic

### Description
Revert the usage of a dev branch of paramedic

### Testing
none

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
