### PR TITLE
fix(android): hide nav & title bars when fullscreen is enabled

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -32,6 +32,7 @@ import android.view.Display;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
+import android.view.Window;
 import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.view.animation.AlphaAnimation;
@@ -314,15 +315,47 @@ public class SplashScreen extends CordovaPlugin {
 
                 // Create and show the dialog
                 splashDialog = new Dialog(context, android.R.style.Theme_Translucent_NoTitleBar);
-                // check to see if the splash screen should be full screen
-                if ((cordova.getActivity().getWindow().getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN)
-                        == WindowManager.LayoutParams.FLAG_FULLSCREEN) {
-                    splashDialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+
+                // Check to see if the splash screen should be full screen.
+                // On first run, currently cordova hasn't set the window flags yet because it does it in
+                //  onWindowFocusChanged instead of onCreate. If that's the case, we'll fall back to the
+                //  Fullscreen preference. Hopefully it will get fixed so that cordova sets them in onCreate,
+                //  so that this fallback can be removed.
+                boolean isFullscreen = false;
+                int mainWindowFlags = cordova.getActivity().getWindow().getAttributes().flags;
+                boolean flagFullscreen = (mainWindowFlags & WindowManager.LayoutParams.FLAG_FULLSCREEN)
+                        == WindowManager.LayoutParams.FLAG_FULLSCREEN;
+                boolean flagForceNotFullscreen = (mainWindowFlags & WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
+                        == WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN;
+
+                // If cordova has set flags, one of these must be true.
+                if (flagFullscreen || flagForceNotFullscreen) {
+                    isFullscreen = flagFullscreen;
+                } else {
+                    // Cordova hasn't set flags, fall back to reading preference.
+                    isFullscreen = preferences.getBoolean("Fullscreen", false);
+                }
+
+                Window dialogWindow = splashDialog.getWindow();
+                if (isFullscreen) {
+                    dialogWindow.setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                             WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
                 splashDialog.setContentView(splashImageView);
                 splashDialog.setCancelable(false);
                 splashDialog.show();
+
+                if (isFullscreen) {
+                    // These must be set after .show() is called because they only work on visible views.
+                    // When the splashscreen hides, the app will revert to whatever was set in CordovaActivity
+                    dialogWindow.getDecorView().setSystemUiVisibility(
+                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+                }
 
                 if (preferences.getBoolean("ShowSplashScreenSpinner", true)) {
                     spinnerStart();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
This is a fix for https://github.com/apache/cordova-plugin-splashscreen/issues/180
The issue is that when the app is supposed to be in fullscreen mode, the nav and title bars still display while the splashscreen is visible.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
Cordova's main activity currently doesn't set the fullscreen flag until it gets focus, so when we check it on plugin init, it's always false. I've added a fallback to read the `Fullscreen` preference if cordova hasn't set flags yet. Long term, I'm planning on doing a separate PR to the cordova-android repo to fix it so that it sets it in `onCreate` instead.

Note: The issue is 90% fixed, but the nav and title bars still flash in briefly when the splashscreen hides. This is because cordova's activity hasn't set its view flags yet and hasn't gotten focus yet. The separate PR to cordova-android will fix this.

### Testing
Ran `npm test`, manually tested the 3 cases of not fullscreen, Fullscreen, and FullscreenNotImmersive.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary

---
closes #180
