### PR TITLE
fix(android): center spinner position on Android 9

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -396,6 +396,7 @@ public class SplashScreen extends CordovaPlugin {
 
                 spinnerDialog.show();
                 spinnerDialog.setContentView(centeredLayout);
+                spinnerDialog.getWindow().setGravity(Gravity.CENTER);
             }
         });
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### Motivation and Context
Fixes #184 

### Description
Android 9 changed the position of the ProgressDialog. This restores the same behavior of previous Android versions where the ProgressBar (and Dialog) is centered on the screen.

### Testing
cordova create app
cordova platform add android
cordova plugin add https://github.com/bozzaj/cordova-plugin-splashscreen
cordova run android --device

Verified that the spinner was centered on the screen.

### Checklist

- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
