### PR TITLE
test: force cordova-ios@^5.1.1

### DIFF
--- a/tests/ios/package.json
+++ b/tests/ios/package.json
@@ -5,7 +5,7 @@
     "author": "Apache Software Foundation",
     "license": "Apache Version 2.0",
     "dependencies": {
-        "cordova-ios": "*"
+        "cordova-ios": "^5.1.1"
     },
     "scripts": {
         "test": "xcodebuild test -workspace CDVSplashScreenTest.xcworkspace -scheme CDVSplashScreenLibTests -destination 'platform=iOS Simulator,name=iPhone 5' CONFIGURATION_BUILD_DIR='/tmp' HEADER_SEARCH_PATHS='$(OBJROOT)/UninstalledProducts/$(PLATFORM_NAME)/include'"


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation and Context

- Force tests to use Cordova-iOS 5.1.1

### Testing

- Using PR Test Run

### Checklist
