### PR TITLE
[Android] Add size specs for Splash Screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ projectRoot
 ```xml
 <platform name="android">
     <!-- you can use any density that exists in the Android project -->
+    <!--
+            land-hdpi    : 800x480 px
+            land-ldpi    : 320x200 px
+            land-mdpi    : 480x320 px
+            land-xhdpi   : 1280x720 px
+            land-xxhdpi  : 1600x960 px
+            land-xxxhdpi : 1920x1280 px
+
+            port-hdpi    : 480x800 px
+            port-ldpi    : 200x320 px
+            port-mdpi    : 320x480 px
+            port-xhdpi   : 720x1280 px
+            port-xxhdpi  : 960x1600 px
+            port-xxxhdpi : 1280x1920 px
+        -->
     <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi" />
     <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi" />
     <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi" />


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
Add size specs for Splash Screens.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
