### PR TITLE
breaking: bump engine restriction for cordova dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "cordova-android": ">=3.6.0",
         "cordova-windows": ">=4.4.0"
       },
-      "6.0.0": {
+      "7.0.0": {
         "cordova": ">100"
       }
     },


### PR DESCRIPTION
### Platforms affected

all

### Motivation and Context

Bump the engine restriction of Cordova dependency so that the next version of the plugin can install.

### Description

* Changed version `6.0.0` to `7.0.0`

### Testing

- Check CI Services Test Results