### PR TITLE
breaking: drop node engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
       "6.0.0": {
         "cordova": ">100"
       }
-    },
-    "node": ">=10.0.0"
+    }
   },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "cordova": ">100"
       }
     },
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Motivation, Context & Description

* In a production environment, our plugins do not execute node related code and does not need the engine check.
* In the environment of developing this plugin, the linting tool is the only node based library which has already defined the node engine requirement. We do not need to set the engine since the lint tool will report, when not valid.

**Example:**
> npm WARN notsup Unsupported engine for @cordova/eslint-config@3.0.0: wanted: {"node":">= 10.13.0"} (current: {"node":"8.17.0","npm":"6.13.4"})
> npm WARN notsup Not compatible with your version of node/npm: @cordova/eslint-config@3.0.0