### PR TITLE
chore: update engine checks to cover newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "2.0.0": {
         "cordova-android": ">=3.6.0"
       },
-      "4.0.0": {
+      ">=4.0.0": {
         "cordova-android": ">=3.6.0",
         "cordova-windows": ">=4.4.0"
       },


### PR DESCRIPTION
In plugin.xml we still require cordova-android >=3.6.0 and cordova-windows >=4.4.0, but the engines in package.json are not updated since version 4 and not taken into account on version 5 and 6.

So changing the 4.0.0 to >=4.0.0 it should cover 5 and 6 too