### PR TITLE
chore: add missing supported platform browser to npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "splashscreen",
     "ecosystem:cordova",
     "cordova-android",
-    "cordova-windows"
+    "cordova-windows",
+    "cordova-browser"
   ],
   "scripts": {
     "test": "npm run lint",


### PR DESCRIPTION
### Motivation, Context & Description

npm keywords was missing `cordova-browser` as a supported platform. This PR added the keyword.
