### PR TITLE
fix: js clobber only on supported platforms

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,10 +33,6 @@
         <engine name="cordova-windows" version=">=4.4.0" />
     </engines>
 
-    <js-module src="www/splashscreen.js" name="SplashScreen">
-        <clobbers target="navigator.splashscreen" />
-    </js-module>
-
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
@@ -47,6 +43,10 @@
         </config-file>
 
         <source-file src="src/android/SplashScreen.java" target-dir="src/org/apache/cordova/splashscreen" />
+
+        <js-module src="www/splashscreen.js" name="SplashScreen">
+            <clobbers target="navigator.splashscreen" />
+        </js-module>
     </platform>
 
     <!-- windows -->
@@ -54,12 +54,20 @@
         <js-module src="src/windows/SplashScreenProxy.js" name="SplashScreenProxy">
             <runs />
         </js-module>
+
+        <js-module src="www/splashscreen.js" name="SplashScreen">
+            <clobbers target="navigator.splashscreen" />
+        </js-module>
     </platform>
 
     <!-- browser -->
     <platform name="browser">
         <js-module src="src/browser/SplashScreenProxy.js" name="SplashScreenProxy">
             <runs />
+        </js-module>
+
+        <js-module src="www/splashscreen.js" name="SplashScreen">
+            <clobbers target="navigator.splashscreen" />
         </js-module>
     </platform>
 </plugin>


### PR DESCRIPTION
### Platforms affected

all

### Motivation and Context

The shared JS content is being clobbered on all platforms even if the platform is not supported.

iOS is affected by this clobber because it has its own JS file that is clobbered on the same `window.navigator` scope.

### Description

Move the shared JS clobber into each defined platform until a better solution is implemented to be more strict on plugin installs.

### Testing

- plugin install & simulator run
  - With mobile spec
  - Without mobile spec
  - With changes
  - With out changes

### Checklist

- [x] I've run the tests to see all new and existing tests pass
