### PR TITLE
(docs): Add Information about how to use Dark Mode SplashScreens

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ If not all DPI images are considered, some devices might not show a SplashScreen
 
 #### Dark Mode (API 28+)
 
-You can easily provide an extra SplashScreen image for NightMode/DarkMode enabled devices.
-To do this, add the keyword `-night` in between the image's **layout** and **size** keywords of the `density` attribute value. E.g.: `land-night-hdpi`
+You can optionally provide an extra SplashScreen image to be used in dark/night mode when enabled on supported devices.
+To do this, add the `-night` keyword in between the **layout** and **size** keywords of the image's `density` attribute value. E.g.: `land-night-hdpi`
 
 For more examples, please see [the Example Configuration](#example-android-configuration) section.
 
@@ -369,7 +369,7 @@ The above looks like the following in `config.xml`:
 
 ##### Dark Mode
 
-Since [Cordova-ios@6.1.0](https://github.com/apache/cordova-ios) it is now possible to use optionally different splashscreen images when your app is running in dark mode. You can configure these images in config.xml with the ~dark suffix (and ~light is also supported).
+Since [Cordova-ios@6.1.0](https://github.com/apache/cordova-ios) it is now possible to optionally specify different SplashScreen images to be used when your app is running in dark mode. You can specify the luminosity of SplashScreen images in config.xml using the ~dark and ~light suffixes.
 
 ```xml
 <!-- Default image to be used for all modes -->
@@ -382,7 +382,7 @@ Since [Cordova-ios@6.1.0](https://github.com/apache/cordova-ios) it is now possi
 <splash src="res/screen/ios/Default@2x~universal~anyany~light.png" />
 ```
 
-**Note:** This works since iOS13+. Version below will use the default SplashScreen without a luminosity suffix specified.
+**Note:** This works since iOS 13. iOS 12 and below will use the default SplashScreen without a luminosity suffix specified.
 
 ##### Quirks and Known Issues
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If not all DPI images are considered, some devices might not show a SplashScreen
 #### Dark Mode
 
 You can easily provide an extra SplashScreen Image for NightMode/DarkMode enabled Devices.
-Do this by addign **-night** at the correct Place in the `density`.
+To do this, add the keyword `-night` in between the image's **layout** and **size** keywords of the `density` attribute value. E.g.: `land-night-hdpi`
 
 The correct Place is between the Image Layout and the Size. See [the Example Configuration](#example-android-configuration).
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ The above looks like the following in `config.xml`:
 
 ##### Dark Mode
 
-Since [Cordova-ios@6.1.0](https://github.com/apache/cordova-ios) it is now possible to optionally specify different SplashScreen images to be used when your app is running in dark mode. You can specify the luminosity of SplashScreen images in config.xml using the ~dark and ~light suffixes.
+Since [Cordova-iOS@6.1.0](https://github.com/apache/cordova-ios), it is now possible to optionally specify different SplashScreen images to use when the app is running in dark mode. The luminosity of SplashScreen images can be defined in `config.xml` using the `~dark` and `~light` suffixes.
 
 ```xml
 <!-- Default image to be used for all modes -->

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This plugin displays and hides a splash screen while your web application is lau
       - [Image Layout](#image-layout)
       - [`density`](#density)
       - [Image Sizing Table](#image-sizing-table)
+      - [Dark Mode](#dark-mode)
       - [Example Android Configuration](#example-android-configuration)
     - [iOS-specific Information](#ios-specific-information)
       - [Launch Storyboard Images](#launch-storyboard-images)
@@ -47,6 +48,7 @@ This plugin displays and hides a splash screen while your web application is lau
         - [Size classes](#size-classes)
         - [Single-image launch screen](#single-image-launch-screen)
         - [Multi-image launch screen](#multi-image-launch-screen)
+        - [Dark Mode](#dark-mode)
         - [Quirks and Known Issues](#quirks-and-known-issues)
     - [Windows-specific Information](#windows-specific-information)
   - [Preferences](#preferences)
@@ -177,6 +179,12 @@ If not all DPI images are considered, some devices might not show a SplashScreen
 | xxhdpi  | 960x1600  | 1600x960  |
 | xxxhdpi | 1280x1920 | 1920x1280 |
 
+#### Dark Mode
+
+You can easily provide an extra SplashScreen Image for NightMode/DarkMode enabled Devices. Do this by addign **-night** at the correct Place in the `density`.
+
+The correct Place is between the Image Layout and the Size. See [the Example Configuration](#example-android-configuration).
+
 #### Example Android Configuration
 
 ```xml
@@ -194,6 +202,21 @@ If not all DPI images are considered, some devices might not show a SplashScreen
     <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi" />
     <splash src="res/screen/android/splash-port-xxhdpi.png" density="port-xxhdpi" />
     <splash src="res/screen/android/splash-port-xxxhdpi.png" density="port-xxxhdpi" />
+  
+    <!-- Dark Mode -->
+    <splash src="res/screen/android/splash-land-hdpi.png" density="land-night-hdpi" />
+    <splash src="res/screen/android/splash-land-ldpi.png" density="land-night-ldpi" />
+    <splash src="res/screen/android/splash-land-mdpi.png" density="land-night-mdpi" />
+    <splash src="res/screen/android/splash-land-xhdpi.png" density="land-night-xhdpi" />
+    <splash src="res/screen/android/splash-land-xxhdpi.png" density="land-night-xxhdpi" />
+    <splash src="res/screen/android/splash-land-xxxhdpi.png" density="land-night-xxxhdpi" />
+
+    <splash src="res/screen/android/splash-port-hdpi.png" density="port-night-hdpi" />
+    <splash src="res/screen/android/splash-port-ldpi.png" density="port-night-ldpi" />
+    <splash src="res/screen/android/splash-port-mdpi.png" density="port-night-mdpi" />
+    <splash src="res/screen/android/splash-port-xhdpi.png" density="port-night-xhdpi" />
+    <splash src="res/screen/android/splash-port-xxhdpi.png" density="port-night-xxhdpi" />
+    <splash src="res/screen/android/splash-port-xxxhdpi.png" density="port-night-xxxhdpi" />
 </platform>
 ```
 
@@ -341,6 +364,21 @@ The above looks like the following in `config.xml`:
     <splash src="res/screen/ios/Default@3x~iphone~comany.png" />
     <splash src="res/screen/ios/Default@2x~ipad~anyany.png" />
     <splash src="res/screen/ios/Default@2x~ipad~comany.png" />
+```
+
+##### Dark Mode
+
+Since [Cordova-ios@6.1.0](https://github.com/apache/cordova-ios) it is now possible to use optionally different splashscreen images when your app is running in dark mode. You can configure these images in config.xml with the ~dark suffix (and ~light is also supported).
+
+```xml
+<!-- Default image to be used for all modes -->
+<splash src="res/screen/ios/Default@2x~universal~anyany.png" />
+
+<!-- Image to use specifically for dark mode devices -->
+<splash src="res/screen/ios/Default@2x~universal~anyany~dark.png" />
+
+<!-- Image to use specifically for light mode devices -->
+<splash src="res/screen/ios/Default@2x~universal~anyany~light.png" />
 ```
 
 ##### Quirks and Known Issues

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ If not all DPI images are considered, some devices might not show a SplashScreen
 You can easily provide an extra SplashScreen Image for NightMode/DarkMode enabled Devices.
 To do this, add the keyword `-night` in between the image's **layout** and **size** keywords of the `density` attribute value. E.g.: `land-night-hdpi`
 
-The correct Place is between the Image Layout and the Size. See [the Example Configuration](#example-android-configuration).
+For more examples, please see [the Example Configuration](#example-android-configuration) section.
 
 #### Example Android Configuration
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This plugin displays and hides a splash screen while your web application is lau
         - [Size classes](#size-classes)
         - [Single-image launch screen](#single-image-launch-screen)
         - [Multi-image launch screen](#multi-image-launch-screen)
-        - [Dark Mode](#dark-mode)
+        - [Dark Mode](#dark-mode-1)
         - [Quirks and Known Issues](#quirks-and-known-issues)
     - [Windows-specific Information](#windows-specific-information)
   - [Preferences](#preferences)
@@ -181,7 +181,8 @@ If not all DPI images are considered, some devices might not show a SplashScreen
 
 #### Dark Mode
 
-You can easily provide an extra SplashScreen Image for NightMode/DarkMode enabled Devices. Do this by addign **-night** at the correct Place in the `density`.
+You can easily provide an extra SplashScreen Image for NightMode/DarkMode enabled Devices.
+Do this by addign **-night** at the correct Place in the `density`.
 
 The correct Place is between the Image Layout and the Size. See [the Example Configuration](#example-android-configuration).
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ If not all DPI images are considered, some devices might not show a SplashScreen
 
 #### Dark Mode
 
-You can easily provide an extra SplashScreen Image for NightMode/DarkMode enabled Devices.
+You can easily provide an extra SplashScreen image for NightMode/DarkMode enabled devices.
 To do this, add the keyword `-night` in between the image's **layout** and **size** keywords of the `density` attribute value. E.g.: `land-night-hdpi`
 
 For more examples, please see [the Example Configuration](#example-android-configuration) section.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If not all DPI images are considered, some devices might not show a SplashScreen
 | xxhdpi  | 960x1600  | 1600x960  |
 | xxxhdpi | 1280x1920 | 1920x1280 |
 
-#### Dark Mode
+#### Dark Mode (API 28+)
 
 You can easily provide an extra SplashScreen image for NightMode/DarkMode enabled devices.
 To do this, add the keyword `-night` in between the image's **layout** and **size** keywords of the `density` attribute value. E.g.: `land-night-hdpi`
@@ -381,6 +381,8 @@ Since [Cordova-ios@6.1.0](https://github.com/apache/cordova-ios) it is now possi
 <!-- Image to use specifically for light mode devices -->
 <splash src="res/screen/ios/Default@2x~universal~anyany~light.png" />
 ```
+
+**Note:** This works since iOS13+. Version below will use the default SplashScreen without a luminosity suffix specified.
 
 ##### Quirks and Known Issues
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Just a Documentation Change

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Dark Mode SplashScreens now work on both: iOS and Android. To let people know how to use them i created this documentation change. #246 

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
