### PR TITLE
chore(docs): Update missing  default resources for Android #689

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,19 @@ For more examples, please see [the Example Configuration](#example-android-confi
 
 ```xml
 <platform name="android">
+    <!-- Default 
+    Note: You should specify default resources for each density.
+      -- For instance, if the device(hdpi) is in landscape orientation and [density="land-hdpi"] 
+      -- does not exists, [density="hdpi"] will be selected 
+      If you do not declare this you will get MissingDefaultResource lint check errors.
+      -->
+    <splash src="res/screen/android/splash-port-hdpi.png" density="hdpi"/>
+    <splash src="res/screen/android/splash-port-ldpi.png" density="ldpi"/>
+    <splash src="res/screen/android/splash-port-mdpi.png" density="mdpi"/>
+    <splash src="res/screen/android/splash-port-xhdpi.png" density="xhdpi"/>
+    <splash src="res/screen/android/splash-port-xxhdpi.png" density="xxhdpi"/>
+
+    <!-- Landscape -->
     <splash src="res/screen/android/splash-land-hdpi.png" density="land-hdpi" />
     <splash src="res/screen/android/splash-land-ldpi.png" density="land-ldpi" />
     <splash src="res/screen/android/splash-land-mdpi.png" density="land-mdpi" />
@@ -197,6 +210,7 @@ For more examples, please see [the Example Configuration](#example-android-confi
     <splash src="res/screen/android/splash-land-xxhdpi.png" density="land-xxhdpi" />
     <splash src="res/screen/android/splash-land-xxxhdpi.png" density="land-xxxhdpi" />
 
+    <!-- Portrait -->
     <splash src="res/screen/android/splash-port-hdpi.png" density="port-hdpi" />
     <splash src="res/screen/android/splash-port-ldpi.png" density="port-ldpi" />
     <splash src="res/screen/android/splash-port-mdpi.png" density="port-mdpi" />


### PR DESCRIPTION
Disclaimer: This is an almost 1 to 1 copy of [228](https://github.com/apache/cordova-plugin-splashscreen/pull/228) that was closed on a technicality 

### Platforms affected
Only docs
 
### Motivation and Context
Current documentation lacks the default resources for Android.
On Android, you can provide alternative resources for specific device configuration, like current docs provide alternative resources for portrait and landscape orientation. But error will be thrown if a device configuration does not match any specific alternative resources, so you should provide a default (In this case, without port- or land- ) as a fallback.
This change fixes the error reported in #185 and [apache/cordova-android#689](https://github.com/apache/cordova-android/issues/689).
 
### Description
[Although orientation is only portrait and landscape as of now](https://developer.android.com/guide/topics/resources/providing-resources#OrientationQualifier), providing default would prevent [MissingDefaultResource lint check error](http://tools.android.com/tips/lint-checks) and considered as [good practice for Android resources configuration](https://developer.android.com/guide/topics/resources/providing-resources#Compatibility).
 
> Likewise, if you provide different layout resources based on the screen orientation, you should pick one orientation as your default. For example, instead of providing layout resources in layout-land/ for landscape and layout-port/ for portrait, leave one as the default, such as layout/ for landscape and layout-port/ for portrait.
 
Note:
You don’t have to provide a default for screen density. [The system use whichever resources are the best match](https://developer.android.com/guide/topics/resources/providing-resources#DensityQualifier).

### Testing
### Checklist
* [ ]  I've run the tests to see all new and existing tests pass
* [ ]  I added automated test coverage as appropriate for this change
* [ ]  Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
* [x]  If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
* [x]  I've updated the documentation if necessary
