### PR TITLE
[Android] [Enhancement] [Docs] Add missing (night) to file names of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,19 +205,19 @@ For more examples, please see [the Example Configuration](#example-android-confi
     <splash src="res/screen/android/splash-port-xxxhdpi.png" density="port-xxxhdpi" />
   
     <!-- Dark Mode -->
-    <splash src="res/screen/android/splash-land-hdpi.png" density="land-night-hdpi" />
-    <splash src="res/screen/android/splash-land-ldpi.png" density="land-night-ldpi" />
-    <splash src="res/screen/android/splash-land-mdpi.png" density="land-night-mdpi" />
-    <splash src="res/screen/android/splash-land-xhdpi.png" density="land-night-xhdpi" />
-    <splash src="res/screen/android/splash-land-xxhdpi.png" density="land-night-xxhdpi" />
-    <splash src="res/screen/android/splash-land-xxxhdpi.png" density="land-night-xxxhdpi" />
+    <splash src="res/screen/android/splash-land-night-hdpi.png" density="land-night-hdpi" />
+    <splash src="res/screen/android/splash-land-night-ldpi.png" density="land-night-ldpi" />
+    <splash src="res/screen/android/splash-land-night-mdpi.png" density="land-night-mdpi" />
+    <splash src="res/screen/android/splash-land-night-xhdpi.png" density="land-night-xhdpi" />
+    <splash src="res/screen/android/splash-land-night-xxhdpi.png" density="land-night-xxhdpi" />
+    <splash src="res/screen/android/splash-land-night-xxxhdpi.png" density="land-night-xxxhdpi" />
 
-    <splash src="res/screen/android/splash-port-hdpi.png" density="port-night-hdpi" />
-    <splash src="res/screen/android/splash-port-ldpi.png" density="port-night-ldpi" />
-    <splash src="res/screen/android/splash-port-mdpi.png" density="port-night-mdpi" />
-    <splash src="res/screen/android/splash-port-xhdpi.png" density="port-night-xhdpi" />
-    <splash src="res/screen/android/splash-port-xxhdpi.png" density="port-night-xxhdpi" />
-    <splash src="res/screen/android/splash-port-xxxhdpi.png" density="port-night-xxxhdpi" />
+    <splash src="res/screen/android/splash-port-night-hdpi.png" density="port-night-hdpi" />
+    <splash src="res/screen/android/splash-port-night-ldpi.png" density="port-night-ldpi" />
+    <splash src="res/screen/android/splash-port-night-mdpi.png" density="port-night-mdpi" />
+    <splash src="res/screen/android/splash-port-night-xhdpi.png" density="port-night-xhdpi" />
+    <splash src="res/screen/android/splash-port-night-xxhdpi.png" density="port-night-xxhdpi" />
+    <splash src="res/screen/android/splash-port-night-xxxhdpi.png" density="port-night-xxxhdpi" />
 </platform>
 ```
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Just add missing `night` word in the file names of images.


### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
