### PR TITLE
applied changes in SplashScreen that allows get ScaleType and backgroundColor from preferences

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -125,6 +125,10 @@ public class SplashScreen extends CordovaPlugin {
         return preferences.getBoolean("SplashMaintainAspectRatio", false);
     }
 
+    private String getSplashScaleType() {
+        return preferences.getString("SplashScaleType", "FIT_XY");
+    }
+
     private int getFadeDuration () {
         int fadeSplashScreenDuration = preferences.getBoolean("FadeSplashScreen", true) ?
             preferences.getInteger("FadeSplashScreenDuration", DEFAULT_FADE_DURATION) : 0;
@@ -301,16 +305,9 @@ public class SplashScreen extends CordovaPlugin {
                 splashImageView.setMinimumWidth(display.getWidth());
 
                 // TODO: Use the background color of the webView's parent instead of using the preference.
-                splashImageView.setBackgroundColor(preferences.getInteger("backgroundColor", Color.BLACK));
+                splashImageView.setBackgroundColor(Color.parseColor(preferences.getString("SplashBackgroundColor", "#FFFFFF")));
 
-                if (isMaintainAspectRatio()) {
-                    // CENTER_CROP scale mode is equivalent to CSS "background-size:cover"
-                    splashImageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
-                }
-                else {
-                    // FIT_XY scales image non-uniformly to fit into image view.
-                    splashImageView.setScaleType(ImageView.ScaleType.FIT_XY);
-                }
+                splashImageView.setScaleType(ImageView.ScaleType.valueOf(getSplashScaleType()));
 
                 // Create and show the dialog
                 splashDialog = new Dialog(context, android.R.style.Theme_Translucent_NoTitleBar);
@@ -393,6 +390,7 @@ public class SplashScreen extends CordovaPlugin {
 
                 spinnerDialog.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
                 spinnerDialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+                spinnerDialog.getWindow().setGravity(Gravity.CENTER);
 
                 spinnerDialog.show();
                 spinnerDialog.setContentView(centeredLayout);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Need to set ScaleType of splashscreen, and with this, the backgroundColor is also needed.


### Description
<!-- Describe your changes in detail -->
With this changes, only thing you need to do is set the preferences on config.xml.
To make things easier, hexadecimal colors can be used in preferences "#FFFFFF".
example:
preference name="SplashScaleType" value="CENTER_INSIDE"
preference name="SplashBackgroundColor" value="#232323"
if no preferences, FIT_XY and #FFFFFF will be the default.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
