### PR TITLE
Fix(android): autofocus don't work after splashscreen

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -194,6 +194,7 @@ public class SplashScreen extends CordovaPlugin {
         } else if ("spinner".equals(id)) {
             if ("stop".equals(data.toString())) {
                 getView().setVisibility(View.VISIBLE);
+                getView().requestFocus();
             }
         } else if ("onReceivedError".equals(id)) {
             this.spinnerStop();


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
simple input with autofocus doesn't get focus on startup on Android > 8

### Description
requestFocus on webview after restore visibility

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
