### PR TITLE
fix: refocus after webview visible (#186)

### DIFF
--- a/src/android/SplashScreen.java
+++ b/src/android/SplashScreen.java
@@ -194,6 +194,7 @@ public class SplashScreen extends CordovaPlugin {
         } else if ("spinner".equals(id)) {
             if ("stop".equals(data.toString())) {
                 getView().setVisibility(View.VISIBLE);
+                getView().requestFocus();
             }
         } else if ("onReceivedError".equals(id)) {
             this.spinnerStop();


### PR DESCRIPTION
### Platforms affected
android


### Motivation and Context
After Android SDK 28, the android buck-button key event can not be handled. 
This issue happens because the webview gets out of focus.
This PR made the webview to refocus after url loading.

fixes: #186

### Description


### Testing
In my local environment I tested by creating sample app with cordova-android 9.1.0 and cordova 10.0.0.
I also run ` npm run test`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
