### PR TITLE
chore: update android engine requirement <11.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ This plugin displays and hides a splash screen while your web application is lau
 - Android
   __Note__: Android implementation has been moved to the core framework.
     If using `cordova-android@10.x` or earlier, use `cordova-plugin-splashscreen@6.x`
-    If using `cordova-android@11.x` or later, use `cordova-plugin-splashscreen@7.x` (currently in-development).
-    If developing exclusively for the Android platform, this plugin can be uninstalled.
+    If using `cordova-android@11.x` or later and exclusively developing for Android, this plugin can be uninstalled.
 - iOS  
   __Note__: iOS implementation has been moved to the core framework.  
     If using `cordova-ios@5` or earlier, use `cordova-plugin-splashscreen@5`  

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ This plugin displays and hides a splash screen while your web application is lau
 ## Supported Platforms
 
 - Android
+  __Note__: Android implementation has been moved to the core framework.
+    If using `cordova-android@10.x` or earlier, use `cordova-plugin-splashscreen@6.x`
+    If using `cordova-android@11.x` or later, use `cordova-plugin-splashscreen@7.x` (currently in-development).
+    If developing exclusively for the Android platform, this plugin can be uninstalled.
 - iOS  
   __Note__: iOS implementation has been moved to the core framework.  
     If using `cordova-ios@5` or earlier, use `cordova-plugin-splashscreen@5`  

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,10 @@
           "2.0.0": {
             "cordova-android": ">=3.6.0"
           },
+          "6.0.2": {
+            "cordova-android": ">=3.6.0 <11.0.0",
+            "cordova-windows": ">=4.4.0"
+          },
           "7.0.0": {
             "cordova": ">100"
           }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
         "cordova-android": ">=3.6.0",
         "cordova-windows": ">=4.4.0"
       },
+      "6.0.2": {
+        "cordova-android": ">=3.6.0 <11.0.0",
+        "cordova-windows": ">=4.4.0"
+      },
       "7.0.0": {
         "cordova": ">100"
       }

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,7 @@
     <issue>https://github.com/apache/cordova-plugin-splashscreen/issues</issue>
 
     <engines>
-        <engine name="cordova-android" version=">=3.6.0" /><!-- Requires CordovaPlugin.preferences -->
+        <engine name="cordova-android" version=">=3.6.0 <11.0.0" /><!-- Requires CordovaPlugin.preferences -->
         <engine name="cordova-windows" version=">=4.4.0" />
     </engines>
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The Cordova Android platform has inegrated the Splash Screen plugin as core functionality.
This plugin is no longer needed in in the next majpr release of Cordova Android (11.0.0+).

### Description
<!-- Describe your changes in detail -->

Update the engine requirement to not install on 11.0.0 or above.

### Testing
<!-- Please describe in detail how you tested your changes. -->


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
