### PR TITLE
doc(readme): remove iOS docs (migrated to cordova-docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ description: Control the splash screen for your app.
 
 # cordova-plugin-splashscreen
 
-[![Android Testsuite](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/android.yml/badge.svg)](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/android.yml) [![Chrome Testsuite](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/chrome.yml/badge.svg)](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/chrome.yml) [![iOS Testsuite](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/ios.yml/badge.svg)](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/ios.yml) [![Lint Test](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/lint.yml/badge.svg)](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/lint.yml)
+[![Android Testsuite](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/android.yml/badge.svg)](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/android.yml) [![Chrome Testsuite](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/chrome.yml/badge.svg)](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/chrome.yml) [![Lint Test](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/lint.yml/badge.svg)](https://github.com/apache/cordova-plugin-splashscreen/actions/workflows/lint.yml)
 
 This plugin displays and hides a splash screen while your web application is launching. Using its methods you can also show and hide the splash screen manually.
 
@@ -36,29 +36,17 @@ This plugin displays and hides a splash screen while your web application is lau
       - [Image Layout](#image-layout)
       - [`density`](#density)
       - [Image Sizing Table](#image-sizing-table)
-      - [Dark Mode](#dark-mode)
+      - [Dark Mode (API 28+)](#dark-mode-api-28)
       - [Example Android Configuration](#example-android-configuration)
-    - [iOS-specific Information](#ios-specific-information)
-      - [Launch Storyboard Images](#launch-storyboard-images)
-        - [Designing Launch Storyboard Images](#designing-launch-storyboard-images)
-        - [Scale](#scale)
-        - [Idioms](#idioms)
-        - [Size classes](#size-classes)
-        - [Single-image launch screen](#single-image-launch-screen)
-        - [Multi-image launch screen](#multi-image-launch-screen)
-        - [Dark Mode](#dark-mode-1)
-        - [Quirks and Known Issues](#quirks-and-known-issues)
     - [Windows-specific Information](#windows-specific-information)
   - [Preferences](#preferences)
     - [config.xml](#configxml)
     - [Quirks](#quirks)
       - [Android Quirks](#android-quirks)
       - [Browser Quirks](#browser-quirks)
-      - [iOS Quirks](#ios-quirks)
       - [Windows Quirks](#windows-quirks)
   - [Methods](#methods)
     - [splashscreen.hide](#splashscreenhide)
-      - [iOS Quirk](#ios-quirk)
     - [splashscreen.show](#splashscreenshow)
 
 ## Installation
@@ -75,12 +63,8 @@ This plugin displays and hides a splash screen while your web application is lau
   __Note__: Android implementation has been moved to the core framework.
     If using `cordova-android@10.x` or earlier, use `cordova-plugin-splashscreen@6.x`
     If using `cordova-android@11.x` or later and exclusively developing for Android, this plugin can be uninstalled.
-- iOS  
-  __Note__: iOS implementation has been moved to the core framework.  
-    If using `cordova-ios@5` or earlier, use `cordova-plugin-splashscreen@5`  
-    If using `cordova-ios@6` or later, use `cordova-plugin-splashscreen@6`. If developing exclusively for the iOS platform, this plugin can be uninstalled.
 - Windows (`cordova-windows` version >= 4.4.0 is required)  
-  __Note__: Extended splashscreen does not require the plugin on Windows (as opposed to Android and iOS) in case you don't use the plugin API, i.e. programmatic hide/show.
+  __Note__: Extended splashscreen does not require the plugin on Windows (as opposed to Android) in case you don't use the plugin API, i.e. programmatic hide/show.
 - Browser
 
 ## Platform Splash Screen Image Configuration
@@ -105,7 +89,6 @@ projectRoot
     res
         screen
             android
-            ios
             windows
 ```
 
@@ -124,18 +107,6 @@ projectRoot
     <splash src="res/screen/android/splash-port-xhdpi.png" density="port-xhdpi" />
     <splash src="res/screen/android/splash-port-xxhdpi.png" density="port-xxhdpi" />
     <splash src="res/screen/android/splash-port-xxxhdpi.png" density="port-xxxhdpi" /> 
-</platform>
-
-<platform name="ios">
-    <!-- Storyboard (supports all devices):
-      -- Note: images are determined by scale, idiom, and size traits. The following
-      -- are suggested based on current device form factors -->
-    <splash src="res/screen/ios/Default@2x~universal~anyany.png" />
-    <splash src="res/screen/ios/Default@2x~universal~comany.png" />
-    <splash src="res/screen/ios/Default@2x~universal~comcom.png" />
-    <splash src="res/screen/ios/Default@3x~universal~anyany.png" />
-    <splash src="res/screen/ios/Default@3x~universal~anycom.png" />
-    <splash src="res/screen/ios/Default@3x~universal~comany.png" />
 </platform>
 
 <!-- Configuration using MRT concept (Recommended, see "Windows-specific information" section for details): -->
@@ -239,180 +210,6 @@ For more examples, please see [the Example Configuration](#example-android-confi
 </platform>
 ```
 
-### iOS-specific Information
-
-Launch storyboard images are sized based on scale, idiom, and size classes. It supports all devices, and can be used with split-screen/slide-over multitasking.
-
-There is no official support for providing a native-resolution launch image for the iPad Pro 12.9 or for providing launch images that work with split-screen multitasking or slide-over.
-
-**Note:** Since iOS 11, for iPhone X devices and greater (with notch screen), make sure to add `viewport-fit=cover` to the viewport meta tag in your `index.html` file to display the app correctly like so: `<meta name="viewport" content="user-scalable=no, initial-scale=1, width=device-width, viewport-fit=cover">` and make some modification to your app style by adding: `padding: env(safe-area-inset-top)` to your `index.css` file to avoid the unsafe areas behind notches in the screen.
-
-#### Launch Storyboard Images
-
-To support newer form factors and split-screen/slide-over multitasking, launch storyboard images are used.
-
-- images are not specific to a given device.
-- images are scaled to fill the available viewport (while maintaining the aspect ratio).
-- the outer edges of the images will be cropped, and the amount will vary based on device an viewport.
-- there is no need to provide an image for each possible device, viewport, and orientation; iOS will choose the best image for the situation automatically.
-
-##### Designing Launch Storyboard Images
-
-The key to designing a launch storyboard image is understanding that the edges of the image will almost certainly be cropped. Therefore, one should not place any important information near the edges of any images provided to the launch storyboard. Only the center is a safe area, and this all but guarantees that following Apple's advice of presenting an unpopulated user interface will not work well.
-
-Instead, the following tips should enable you to create a launch image that works across a multitude of form factors, viewports, and orientations:
-
-- Important graphics (logos, icons, titles) should be centered. The safe bounding region will vary, so you will need to test to ensure that the important graphics are never cropped. Better yet, don't supply any important graphics in the first place.
-
-  - You _can_ fine-tune the placement and size of these graphics.
-
-- Use a simple color wash. If you use two colors, you'll want one color to fill the top half of the image, and the second to fill the bottom half.  If you use a gradient, you'll probably want to ensure that the middle of the gradient lines up with the center of the image.
-
-- Don't worry about pixel perfection -- because the images are scaled, there's almost no chance the images will be perfectly fit to the pixel grid. Since all supported iOS devices use retina screens, users will be hard pressed to notice it anyway.
-
-It is important to understand the concept of scale, idiom, and size class traits in order to use launch storyboard images effectively. Of the images supplied to the launch storyboard, iOS will choose the image that best matches the device and viewport and render that image. It is possible to supply only one launch image if so desired, but it is also possible to fine-tune the displayed launch image based on traits. When fine-tuning, one can ignore traits that aren't targeted or supported by the app.
-
-##### Scale
-
-|    scale    |    devices             |
-|:-----------:|:----------------------:|
-|     1x      | All non-retina devices |
-|     2x      | Most retina devices    |
-|     3x      | iPhone 6+/6s+,7s+      |
-
-In general, you'll want to supply 2x and 3x images. Cordova only supports retina devices now, so there's no point in supplying 1x images.
-
-##### Idioms
-
-|    idiom    |    devices    |
-|:-----------:|:-------------:|
-|    ipad     | All iPads     |
-|   iphone    | All iPhones and iPod Touches    |
-|  universal  | All devices   |
-
-You only need to provide universal images unless you need to fine-tune for a specific device idiom.
-
-##### Size classes
-
-There are two size classes applies to both screen axes. Narrow viewports are considered to be the "compact" size class, and remaining viewports are considered "regular". When supplying images to Xcode, however, one must choose between "any & compact" and "any & regular". To stay consistent with the native terminology, this feature will match based on "any" and "compact". `any` will match regular-sized viewports. 
-
-Note: this feature uses `com` as an abbreviation for "compact" classes.
-
-The following classes are supported by this feature:
-
-|    width    |    height    |    orientation    |
-|:-----------:|:------------:|:-----------------:|
-|     any     |     any      |        any        |
-|     com     |     any      |     portrait      |
-|     any     |     com      |  landscape (wide) |
-|     com     |     com      | landscape (narrow)|
-
-To see the complete list of size classes associated with devices and viewports, see <http://www.sizeclasses.com>.
-
-##### Single-image launch screen
-
-If your launch image is simple, you may be able to avoid creating a lot of different launch images and supply only one. The launch image needs to meet the following requirements:
-
-- the image should be square
-- the image should be large enough to fit on an iPad Pro 12.9": 2732x2732
-- anything important should fit within the center
-
-Keep in mind that the image will be cropped, possibly quite severely, depending upon the viewport.
-
-Once the image is created, you can include it in your project by adding the following to `config.xml`:
-
-```xml
-    <splash src="res/screen/ios/Default@2x~universal~anyany.png" />
-```
-
-Because only one image is provided, iOS will utilize it in every context.
-
-##### Multi-image launch screen
-
-If a single launch image won't meet your needs, you will probably need to supply at least six images, if not more. Furthermore, keep in mind that it will not be possible to fine tune the image to a specific device, but only to a device class, display factor, and viewport size.
-
-If you don't need to target images to a specific idiom, you should create six images, as follows:
-
-|    scale    |    idiom    |    width    |    height    |    size    |    filename    |
-|:-----------:|:-----------:|:-----------:|:------------:|:----------:|:--------------:|
-|     2x*     |  universal  |     any     |     any      | 2732x2732  | `Default@2x~universal~anyany.png` |
-|     2x      |  universal  |     com     |     any      | 1278x2732  | `Default@2x~universal~comany.png` |
-|     2x      |  universal  |     com     |     com      | 1334x750   | `Default@2x~universal~comcom.png` |
-|     3x*     |  universal  |     any     |     any      | 2208x2208  | `Default@3x~universal~anyany.png` |
-|     3x      |  universal  |     any     |     com      | 2208x1242  | `Default@3x~universal~anycom.png` |
-|     3x      |  universal  |     com     |     any      | 1242x2208  | `Default@3x~universal~comany.png` |
-
-\* this image is required in order for iOS utilize the other images within this scale and idiom.
-
-> Note: If the 3x sizes look small too you, that's because there's only one device class that currently has a 3x density: the iPhone 6+/6s+/7+.
-
-The above looks like the following snippet when present in `config.xml`:
-
-```xml
-    <splash src="res/screen/ios/Default@2x~universal~anyany.png" />
-    <splash src="res/screen/ios/Default@2x~universal~comany.png" />
-    <splash src="res/screen/ios/Default@2x~universal~comcom.png" />
-    <splash src="res/screen/ios/Default@3x~universal~anyany.png" />
-    <splash src="res/screen/ios/Default@3x~universal~anycom.png" />
-    <splash src="res/screen/ios/Default@3x~universal~comany.png" />
-```
-
-Should one need to further fine tune based upon device idiom, one can do so. This might look like so:
-
-|    scale    |    idiom    |    width    |    height    |    size    |    filename    |
-|:-----------:|:-----------:|:-----------:|:------------:|:----------:|:--------------:|
-|     2x*     |    iphone   |     any     |     any      | 1334x1334  | `Default@2x~iphone~anyany.png` |
-|     2x      |    iphone   |     com     |     any      | 750x1334   | `Default@2x~iphone~comany.png` |
-|     2x      |    iphone   |     com     |     com      | 1334x750   | `Default@2x~iphone~comcom.png` |
-|     3x*     |    iphone   |     any     |     any      | 2208x2208  | `Default@3x~iphone~anyany.png` |
-|     3x      |    iphone   |     any     |     com      | 2208x1242  | `Default@3x~iphone~anycom.png` |
-|     3x      |    iphone   |     com     |     any      | 1242x2208  | `Default@3x~iphone~comany.png` |
-|     2x*     |     ipad    |     any     |     any      | 2732x2732  | `Default@2x~ipad~anyany.png`   |
-|     2x      |     ipad    |     com     |     any      | 1278x2732  | `Default@2x~ipad~comany.png`   |
-
-\* this image is required in order for iOS utilize the other images within this scale and idiom.
-
-The above looks like the following in `config.xml`:
-
-```xml
-    <splash src="res/screen/ios/Default@2x~iphone~anyany.png" />
-    <splash src="res/screen/ios/Default@2x~iphone~comany.png" />
-    <splash src="res/screen/ios/Default@2x~iphone~comcom.png" />
-    <splash src="res/screen/ios/Default@3x~iphone~anyany.png" />
-    <splash src="res/screen/ios/Default@3x~iphone~anycom.png" />
-    <splash src="res/screen/ios/Default@3x~iphone~comany.png" />
-    <splash src="res/screen/ios/Default@2x~ipad~anyany.png" />
-    <splash src="res/screen/ios/Default@2x~ipad~comany.png" />
-```
-
-##### Dark Mode
-
-Since [Cordova-iOS@6.1.0](https://github.com/apache/cordova-ios), it is now possible to optionally specify different SplashScreen images to use when the app is running in dark mode. The luminosity of SplashScreen images can be defined in `config.xml` using the `~dark` and `~light` suffixes.
-
-```xml
-<!-- Default image to be used for all modes -->
-<splash src="res/screen/ios/Default@2x~universal~anyany.png" />
-
-<!-- Image to use specifically for dark mode devices -->
-<splash src="res/screen/ios/Default@2x~universal~anyany~dark.png" />
-
-<!-- Image to use specifically for light mode devices -->
-<splash src="res/screen/ios/Default@2x~universal~anyany~light.png" />
-```
-
-**Note:** This works since iOS 13. iOS 12 and below will use the default SplashScreen without a luminosity suffix specified.
-
-##### Quirks and Known Issues
-
-1. **App on target may not reflect changes to images**
-   Once you run the app on a target, iOS caches the launch image. Unfortunately, when you change the image, iOS does _not_ invalidate the cache, which means you'll still see the old launch image. You should either: delete the app, or reset content & settings (simulator).
-
-2. **Simulator may not show expected images when launched from CLI**
-   When Xcode deploys to a specific simulator, it only copies the assets that match the simulator's characteristics. For example, if you try to run an app on the iPhone 6s Plus simulator, only @3x launch images are copied. When compiling from the CLI, however, the default is to assume an iPhone 5s, which means only @2x launch images are copied. Unless your launch images are markedly different, chances are good the difference would go unnoticed, but this does mean that the only accurate method of testing is to test on a physical device.
-
-3. **`anyany` must be provided for other variations to be used**
-   If you don't provide an `anyany` version of the launch image for a specific scale and idiom, the other variations (like `anycom`, `comany`, and `comcom`) will ignored. 
-
 ### Windows-specific Information
 
 Splash screen images can be defined using the [MRT](https://cordova.apache.org/docs/en/dev/config_ref/images.html#windows) concept.  
@@ -463,8 +260,6 @@ __Note__: You may need to reopen Visual Studio solution after changing the image
 
     **Windows Quirk**: You should disable the splashscreen in case you are updating the entire document body dynamically (f.e. with a SPA router) to avoid affecting UI/controls.  
     Note that you should also directly reference `WinJS/base.js` in the page HTML in this case to avoid the issues with activation context ([CB-11658](https://issues.apache.org/jira/browse/CB-11658)).
-
-    **iOS Quirk**: to disable the splashscreen on `ios` platform you should also add `<preference name="FadeSplashScreenDuration" value="0"/>` to `config.xml`.
 
 - `FadeSplashScreen` (boolean, defaults to `true`): Set to `false` to
   prevent the splash screen from fading in and out when its display
@@ -545,10 +340,6 @@ You can use the following preferences in your `config.xml`:
 
 __Note__: `SplashScreen` value should be absolute in order to work in a sub-page. The `SplashScreen` value is used only for the browser platform. The value will be ignored for other platforms.
 
-#### iOS Quirks
-
-- In iOS, the splash screen images are called launch images. These images are mandatory on iOS.
-
 #### Windows Quirks
 
 - `SplashScreenSpinnerColor` (string, defaults to system accent color): hash, rgb notation or CSS color name.
@@ -576,19 +367,6 @@ Dismiss the splash screen.
 
 ```js
 navigator.splashscreen.hide();
-```
-
-
-#### iOS Quirk
-
-The `config.xml` file's `AutoHideSplashScreen` setting must be
-`false`. To delay hiding the splash screen for two seconds, add a
-timer such as the following in the `deviceready` event handler:
-
-```js
-setTimeout(function() {
-    navigator.splashscreen.hide();
-}, 2000);
 ```
 
 ### splashscreen.show


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Splash Screen has been migrated as a core feature of the iOS platform.
This PR is to remove the documentation from the plugin repo and remove any confusion that the plugin still supports iOS.

The iOS related documentation is being migrated to [`cordova-docs`](https://github.com/apache/cordova-docs/pull/1249)

### Description
<!-- Describe your changes in detail -->

Cleanup README

### Testing
<!-- Please describe in detail how you tested your changes. -->


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
